### PR TITLE
Disable service worker in local development

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": true
+    }
+  ]
+}

--- a/app/components/ServiceWorkerRegistration.tsx
+++ b/app/components/ServiceWorkerRegistration.tsx
@@ -7,16 +7,28 @@ export function ServiceWorkerRegistration() {
     // The Capacitor app serves its assets from disk -- they're offline by
     // definition, and service workers don't work reliably in WKWebView.
     if (process.env.NEXT_PUBLIC_APP_MODE === "native") return;
-    if (typeof window !== "undefined" && "serviceWorker" in navigator) {
-      window.addEventListener("load", () => {
-        navigator.serviceWorker
-          .register("/sw.js")
-          .then(() => {
-          })
-          .catch(() => {
-          });
-      });
+    if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+      return;
     }
+
+    // The SW's cache-first strategy serves stale JS/CSS chunks after dev
+    // rebuilds, so skip it in development -- and unregister any service
+    // worker left behind from before this guard existed.
+    if (process.env.NODE_ENV === "development") {
+      navigator.serviceWorker.getRegistrations().then((registrations) => {
+        registrations.forEach((registration) => registration.unregister());
+      });
+      return;
+    }
+
+    window.addEventListener("load", () => {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .then(() => {
+        })
+        .catch(() => {
+        });
+    });
   }, []);
 
   return null;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = 'v2';
 const CACHE_NAME = `arabic-flashcards-${CACHE_VERSION}`;
 const OFFLINE_PAGE = '/';
 
@@ -53,6 +53,10 @@ self.addEventListener('fetch', (event) => {
 
   // Skip non-GET requests
   if (request.method !== 'GET') return;
+
+  // Never cache in local development -- stale JS/CSS chunks break pages
+  // after rebuilds.
+  if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') return;
 
   // Skip if matches skip patterns
   if (SKIP_PATTERNS.some(pattern => pattern.test(request.url))) return;


### PR DESCRIPTION
## What changed

- **`app/components/ServiceWorkerRegistration.tsx`**: skips service worker registration when `NODE_ENV === "development"`, and unregisters any service worker already registered on localhost so existing dev environments self-heal on the next page load — no manual DevTools cleanup needed.
- **`public/sw.js`**: the fetch handler now bypasses caching entirely for `localhost` / `127.0.0.1` as a second layer of defense (also covers `next start` on localhost), and `CACHE_VERSION` is bumped to `v2` so lingering registrations drop their stale caches on activate.
- **`.claude/launch.json`**: dev server launch config for Claude Code preview tooling (used to verify this change).

## Why

The service worker caches `/_next/static/`, `.js`, and `.css` assets cache-first, and its skip patterns let localhost traffic through. In local development this served stale chunks after rebuilds — pages rendered with missing Tailwind classes and old component code until the SW was manually unregistered.

## Verification

Ran the dev server and checked via the browser:
- Fresh load: `navigator.serviceWorker.getRegistrations()` returns 0, no controller.
- Simulated the stale state by manually registering `/sw.js`, then reloaded: the registration was removed after one reload and the controller gone after the second — matching what existing dev browsers will experience.
- No console errors; `npm run lint` passes.

## Note for reviewers

The existing skip pattern `/^https:\/\/(?!localhost|127\.0\.0\.1)/` skips every https URL that isn't localhost — including `https://yallaflash.com` itself — so the SW's dynamic caching has likely never applied in production (which is why this bug only ever showed locally). Left untouched here since fixing it changes production behavior; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)