### PR TITLE
Fix service worker registration missed when load fires before hydration

### DIFF
--- a/app/components/ServiceWorkerRegistration.tsx
+++ b/app/components/ServiceWorkerRegistration.tsx
@@ -8,14 +8,17 @@ export function ServiceWorkerRegistration() {
     // definition, and service workers don't work reliably in WKWebView.
     if (process.env.NEXT_PUBLIC_APP_MODE === "native") return;
     if (typeof window !== "undefined" && "serviceWorker" in navigator) {
-      window.addEventListener("load", () => {
-        navigator.serviceWorker
-          .register("/sw.js")
-          .then(() => {
-          })
-          .catch(() => {
-          });
-      });
+      const register = () => {
+        navigator.serviceWorker.register("/sw.js").catch(() => {});
+      };
+      // The load event may have already fired by the time hydration runs
+      // this effect, in which case the listener would never fire.
+      if (document.readyState === "complete") {
+        register();
+        return;
+      }
+      window.addEventListener("load", register);
+      return () => window.removeEventListener("load", register);
     }
   }, []);
 


### PR DESCRIPTION
## What changed

`ServiceWorkerRegistration` registered `/sw.js` inside a `window.addEventListener("load", ...)` callback. If the `load` event has already fired by the time the component's effect runs — common when hydration completes after load, e.g. on fast connections or with cached assets — the listener never fires and the service worker is never registered for that visit.

The effect now checks `document.readyState === "complete"` and registers immediately in that case; otherwise it attaches the load listener and removes it on unmount. The `NEXT_PUBLIC_APP_MODE === "native"` early return is unchanged.

## Verification

On a local production build (`npm run build && npm start`), loaded the page, unregistered the existing service worker, and reloaded: with `document.readyState` already `"complete"`, `navigator.serviceWorker.getRegistration()` immediately resolved to a registration for `/sw.js`. Before the fix, the same scenario left no service worker registered.

## Note for reviewers

Unrelated to this change: `npm run build` fails in a clean environment because `app/api/feedback/route.ts` instantiates the Resend client at module level and throws when `RESEND_API_KEY` is unset. I built with a dummy key to verify; a lazy-init fix is worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)