### PR TITLE
Design lab: progress panel redesign — "the fold"

### DIFF
--- a/.claude-design/design-brief.json
+++ b/.claude-design/design-brief.json
@@ -1,0 +1,45 @@
+{
+  "scope": "component",
+  "isRedesign": true,
+  "targetPath": "app/v2/components/ProgressPanel.tsx",
+  "targetName": "ProgressPanel",
+  "relatedFiles": ["app/v2/components/CedarForest.tsx", "app/v2/components/ChatWindow.tsx"],
+  "painPoints": [
+    "Panel is a mirror, not a lever — zero actions, every stat is a dead end",
+    "Backlog state (126 due) renders a wall of identical red 0% rows — demoralizing, zero information",
+    "Stats speak SM-2 (mean ease, e^(-t/S)) instead of learner language",
+    "Forest is static decoration — nothing grows, wilts, or responds to taps",
+    "Blur-to-reveal english relies on hover, which does not exist on touch"
+  ],
+  "inspiration": {
+    "visual": ["existing V2 mono/telemetry aesthetic", "Duolingo (game layer)", "Forest app (living metaphor)"],
+    "functional": ["tap-to-act everywhere", "progressive disclosure", "recovery plan over raw backlog"]
+  },
+  "brand": {
+    "adjectives": ["warm", "Lebanese", "science-backed", "playful"],
+    "density": "explore both",
+    "darkMode": false
+  },
+  "persona": {
+    "primary": "End consumer (language learner, often lapsed)",
+    "context": "mobile-first (Capacitor native app, panel in a sheet/sidebar next to a chat tutor)",
+    "keyTasks": [
+      "Understand what to do right now and how long it takes",
+      "Start a review session (especially a small recovery bite under backlog)",
+      "Feel progress and stay motivated to return daily"
+    ]
+  },
+  "constraints": {
+    "mustKeep": ["counts (new/learning/learned)", "forest metaphor available as an option", "works at ~340px width"],
+    "technical": ["no new dependencies", "Tailwind + existing tokens", "actions modeled as prompts sent to the chat tutor"]
+  },
+  "framework": "nextjs-app",
+  "packageManager": "npm",
+  "stylingSystem": "tailwind",
+  "tokens": {
+    "text": ["text-heading", "text-body", "text-subtle", "text-disabled"],
+    "fonts": ["font-title (PP Hatton)", "font-mono (Geist Mono)"],
+    "radius": "0.5rem base via --radius",
+    "brandAccent": "red pomegranate, cedar greens"
+  }
+}

--- a/.claude-design/run-log.md
+++ b/.claude-design/run-log.md
@@ -1,0 +1,38 @@
+# Design lab run log — ProgressPanel redesign
+
+- Date: 2026-07-07
+- Interview: skipped — brief derived from prior conversation (user asked for max breadth: actionable panel, backlog recovery, forest-as-telemetry, human stats).
+- Route: `app/design-lab/` (App Router treats `_`-prefixed folders as private, so `__design_lab` is not routable).
+- Variants:
+  - A — Mission control (hierarchy + actionability, keeps mono aesthetic)
+  - B — Living forest (forest IS the telemetry, tappable wilting trees)
+  - C — Coach card (tutor voice, one primary door, spacious)
+  - D — Progress HQ (game layer: goal ring, streak, week chart, milestones)
+  - E — Teta's balcony (expressive Lebanese direction, PP Hatton, orchard)
+- Shared fixtures: two scenarios (backlog = the screenshot state with 126 due; healthy). All actions simulate prompts to the chat tutor via an on-page console.
+
+## Round 2 (after user rejected round 1)
+- Feedback: "mix of mission control with something more visual; literal forest is bad UX; all of these look kinda shit". Round 1 also rendered broken in the user's browser (stale dev CSS — invisible green CTAs, no phone frames).
+- Rebuilt: one shared chassis (chassis.tsx: next action → human stats → weakest 5) + three hero visuals:
+  - F Memory field (vocabulary as tappable dot-matrix; overdue = hollow "asleep" rings)
+  - G Orbit (time rings; words fall toward center review zone; count haloed in the zone)
+  - H Forecast (7-day review load chart with the recovery plan drawn in)
+- Deleted round-1 variants A–E. Cleared .next cache + restarted dev server for fresh CSS.
+- Bugs fixed during verify: signed-shift hash gave negative band → NaN satellite coords (use >>>); SSR/client float drift in sin/cos → hydration mismatch (round to 2 decimals); banded dot scatter (coprime-stride permutation).
+
+## Round 3 (user liked F + G, wants prize-worthy; spacing broken again on their side)
+- Root cause of the user's broken spacing (both times): public/sw.js caches /_next static assets on localhost; their browser held stale CSS/JS. Lab page now unregisters the SW + clears arabic-flashcards-* caches on load. Spawned a background task chip to fix SW-in-dev properly.
+- Dropped Forecast (H). Polished the two finalists:
+  - F Memory field: staggered dot entrance, tap-to-spotlight (field dims to 0.22), tap empty space to release, refined palette (fading = amber-500), 52px-fixed legend/detail row so selection doesn't reflow.
+  - G Orbit: true elliptical orbital drift (rotation inside a scale(1,0.8) plane, 160s/rev, pauses while inspecting + reduced-motion), pulsing due zone, haloed labels up the top axis, size-by-strength satellites.
+- Bug found via screenshot: plain string hash gives consecutive values for consecutive suffixes → satellites chained into capsule-looking clumps. Fixed with an imul avalanche mix.
+
+## Rounds 5–8 (condensed)
+- R5: "see brain/memory fading" → K Synapses (neuron net going dark) + L Fading page (words blur per e^(-t/S)); hover-preview added, then fixed to clear on card mouseleave.
+- R6: user picked the words road → M Ledger, N Word drift, O Notebook. Notebook rejected (baseline alignment); vocab pool expanded to 62 entries + distinct sampling (dupes looked like bugs).
+- R7: P "The fold" = L + N synthesis; research grounding: Brath "Visualizing with Text" (weight > blur as data channel), Nicky Case ncase.me/remember (sweet-spot framing).
+- R8 (current): Pudding alts on the fold benchmark — Q Essay (data-in-prose, PP Hatton lede), R Annotated fold (editorial callouts), S Pop quiz ("can you still read these?" blur = real recall), T Three beats (stepper scrollytelling). All verified in preview.
+
+## Cleanup checklist (on finalize or abort)
+- [ ] delete `app/design-lab/`
+- [ ] delete `.claude-design/`

--- a/app/design-lab/AnnotatedVariant.tsx
+++ b/app/design-lab/AnnotatedVariant.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+// Variant R — "Annotated fold"
+// Pudding technique #2: hand-placed annotation. The fold page from P, but
+// two words carry editorial callouts — a green one above your rock-solid
+// word, an amber one below the freshest ghost — like a chart annotated by
+// a person, not a legend.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, sampleKinds, sampleVocab, seeded, type SampleKind } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, DetailRow } from "./chassis";
+
+type Item = { i: number; arabizi: string; english: string; kind: SampleKind };
+
+const KIND_ORDER: Record<SampleKind, number> = { strong: 0, ok: 1, fading: 2, asleep: 3 };
+
+const KIND_STYLE: Record<SampleKind, string> = {
+  strong: "font-semibold text-gray-900",
+  ok: "font-normal text-gray-800 opacity-90",
+  fading: "font-light text-gray-600 opacity-70 blur-[0.4px]",
+  asleep: "font-light text-gray-500 opacity-35 blur-[1.4px]",
+};
+
+const KIND_LABEL: Record<SampleKind, string> = {
+  strong: "bold in your memory",
+  ok: "settled",
+  fading: "losing weight — review soon",
+  asleep: "below the fold — review to lift it back",
+};
+
+const SHOWN = 40;
+
+function buildItems(data: Scenario): Item[] {
+  const kinds = sampleKinds(data, SHOWN, "anno");
+  const vocab = sampleVocab(SHOWN, `${data.key}annov`);
+  return kinds
+    .map((kind, i) => ({ i, arabizi: vocab[i % vocab.length][0], english: vocab[i % vocab.length][1], kind }))
+    .sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || seeded(`${data.key}ao${a.i}`) - seeded(`${data.key}ao${b.i}`));
+}
+
+export function AnnotatedVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [pin, setPin] = useState<Item | null>(null);
+  const [hover, setHover] = useState<Item | null>(null);
+  const sel = pin ?? hover;
+  const items = buildItems(data);
+  const foldAt = items.findIndex((it) => it.kind === "asleep");
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  // Annotate mid-line words so the labels stay inside the card.
+  const heroWordI = items[Math.min(2, items.length - 1)]?.i;
+  const ghostWordI = foldAt !== -1 ? items[Math.min(foldAt + 2, items.length - 1)].i : undefined;
+
+  const word = (it: Item) => {
+    const selected = sel?.i === it.i;
+    const annotation =
+      it.i === heroWordI
+        ? { text: "solid for 47 days", tone: "text-green-700 border-green-300", side: "top" as const }
+        : it.i === ghostWordI
+        ? { text: "slipped 1d ago ↑ start here", tone: "text-amber-600 border-amber-300", side: "bottom" as const }
+        : null;
+    const btn = (
+      <button
+        key={annotation ? undefined : it.i}
+        onMouseEnter={() => setHover(it)}
+        onClick={() => setPin(pin?.i === it.i ? null : it)}
+        aria-label={`${it.arabizi} — ${KIND_LABEL[it.kind]}`}
+        className={cn(
+          "text-[13.5px] leading-6 rounded-sm transition-[filter,opacity,color] duration-300",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+          selected ? "font-semibold text-green-700 opacity-100 blur-0" : KIND_STYLE[it.kind]
+        )}
+      >
+        {it.arabizi}
+      </button>
+    );
+    if (!annotation) return btn;
+    return (
+      <span key={it.i} className="relative inline-flex">
+        {annotation.side === "top" && (
+          <span
+            className={cn(
+              "absolute -top-[15px] left-0 whitespace-nowrap font-mono text-[8.5px] leading-none border-b border-dashed pb-[2px]",
+              annotation.tone
+            )}
+            aria-hidden="true"
+          >
+            {annotation.text}
+          </span>
+        )}
+        {btn}
+        {annotation.side === "bottom" && (
+          <span
+            className={cn(
+              "absolute -bottom-[13px] left-0 whitespace-nowrap font-mono text-[8.5px] leading-none border-t border-dashed pt-[2px]",
+              annotation.tone
+            )}
+            aria-hidden="true"
+          >
+            {annotation.text}
+          </span>
+        )}
+      </span>
+    );
+  };
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${SHOWN} of ${total}`}>The page, annotated</Eyebrow>
+      </div>
+      <div className="px-4 pt-4 pb-1 select-none">
+        <div className="flex flex-wrap items-baseline gap-x-[10px] gap-y-[7px] leading-7">
+          {(foldAt === -1 ? items : items.slice(0, foldAt)).map(word)}
+          {foldAt !== -1 && (
+            <>
+              <div className="w-full flex items-center gap-2 my-2" aria-hidden="true">
+                <span className="flex-1 border-t border-dashed border-amber-300" />
+                <span className="font-mono text-[9px] tracking-[0.1em] text-amber-600">
+                  THE FOLD · {data.dueNow} ASLEEP BELOW
+                </span>
+                <span className="flex-1 border-t border-dashed border-amber-300" />
+              </div>
+              {items.slice(foldAt).map(word)}
+            </>
+          )}
+        </div>
+      </div>
+      <DetailRow
+        word={sel ? { arabizi: sel.arabizi, english: sel.english, note: KIND_LABEL[sel.kind] } : null}
+        onAction={onAction}
+        hint={
+          <>
+            <span>two callouts, placed like an editor would — the rest stays quiet</span>
+            <span className="ml-auto text-disabled shrink-0">hover or tap</span>
+          </>
+        }
+      />
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/ChallengeVariant.tsx
+++ b/app/design-lab/ChallengeVariant.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// Variant S — "Pop quiz"
+// Pudding technique #3: make the reader participate before you explain.
+// Three of your own words, blurred to exactly how well you know them.
+// "Can you still read these?" — if you can't, that IS the diagnosis, and
+// the tap that checks is the same tap that starts fixing it.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, weakestFirst, retention } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, DetailRow, type SpotWord } from "./chassis";
+
+export function ChallengeVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [revealed, setRevealed] = useState<Set<string>>(new Set());
+  const [sel, setSel] = useState<SpotWord | null>(null);
+  const isBacklog = data.dueNow > 20;
+
+  const candidates = weakestFirst(data.words).filter((w) => w.reviewCount > 0 || w.dueInDays < -0.5);
+  const three = isBacklog ? candidates.slice(-3).reverse() : candidates.slice(0, 3);
+  const remaining = Math.max(0, data.dueNow - 3);
+
+  const hero = (
+    <Card onMouseLeave={() => setSel(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right="blur = your actual recall">Pop quiz</Eyebrow>
+      </div>
+      <div className="px-4 pt-3">
+        <h3 className="font-title font-medium text-[19px] leading-snug text-heading">
+          Can you still read these?
+        </h3>
+        <div className="mt-3 flex flex-col gap-1.5">
+          {three.map((w) => {
+            const isRevealed = revealed.has(w.id);
+            const r = retention(w);
+            const overdue = w.dueInDays < -0.5;
+            const blur = isRevealed ? 0 : overdue ? 2.6 : r !== null && r < 0.45 ? 1.4 : 0.7;
+            return (
+              <button
+                key={w.id}
+                onClick={() => {
+                  setRevealed((s) => new Set(s).add(w.id));
+                  setSel({
+                    arabizi: w.arabizi,
+                    english: w.english,
+                    note: overdue
+                      ? `that blur was real — asleep ${Math.round(-w.dueInDays)}d`
+                      : `hanging on at ${Math.round((r ?? 0) * 100)}%`,
+                  });
+                }}
+                className={cn(
+                  "flex items-baseline justify-between rounded-lg px-3 py-2 min-h-[44px] text-left",
+                  "hover:bg-gray-50 active:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 transition-colors"
+                )}
+              >
+                <span
+                  className={cn(
+                    "text-[21px] font-medium transition-[filter,opacity,color] duration-500",
+                    isRevealed ? "text-green-700 opacity-100" : "text-gray-700 opacity-60"
+                  )}
+                  style={{ filter: `blur(${blur}px)` }}
+                >
+                  {w.arabizi}
+                </span>
+                <span
+                  className={cn(
+                    "text-xs transition-opacity duration-500",
+                    isRevealed ? "text-subtle opacity-100" : "opacity-0"
+                  )}
+                >
+                  {isRevealed ? w.english : "?"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        {remaining > 0 && (
+          <p className="mt-2 px-1 text-[11px] text-subtle">
+            …and <span className="font-semibold text-amber-600 tabular-nums">{remaining} more</span> are
+            blurring like this while we talk.
+          </p>
+        )}
+      </div>
+      <DetailRow
+        word={sel}
+        onAction={onAction}
+        hint={
+          <>
+            <span>the blur is honest — it&apos;s your recall, rendered</span>
+            <span className="ml-auto text-disabled shrink-0">tap to check yourself</span>
+          </>
+        }
+      />
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/DriftVariant.tsx
+++ b/app/design-lab/DriftVariant.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+// Variant J — "Drift"
+// The synthesis of F and G: orderly where it carries meaning (one axis:
+// asleep → fading → settled → solid), organic where it should feel alive
+// (words pile into natural drifts, beeswarm-packed, never overlapping).
+// The backlog is a heap on the left you can literally watch shrink.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, VOCAB_LOOKUP } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, hash } from "./chassis";
+
+type Kind = "asleep" | "fading" | "ok" | "strong" | "new";
+type Dot = { i: number; arabizi: string; english: string; kind: Kind; x: number; y: number; r: number };
+
+const KIND_FILL: Record<Kind, string> = {
+  asleep: "none",
+  fading: "#f59e0b",
+  ok: "#4ade80",
+  strong: "#15803d",
+  new: "#e5e7eb",
+};
+
+const KIND_LABEL: Record<Kind, string> = {
+  asleep: "asleep — needs a review",
+  fading: "fading — review soon",
+  ok: "settled",
+  strong: "solid — long time till review",
+  new: "not started yet",
+};
+
+// Axis geometry (viewBox units)
+const X0 = 14;
+const X1 = 274;
+const GROUND = 136; // words pile up from here, like dunes
+const PAD = 0.8;
+
+// Zones along the memory axis, [start, end] as fractions of the axis.
+const ZONES: Record<Exclude<Kind, "new">, [number, number]> = {
+  asleep: [0.0, 0.28],
+  fading: [0.31, 0.51],
+  ok: [0.53, 0.74],
+  strong: [0.76, 1.0],
+};
+
+// Dot radius by kind, plus a whisper of per-word variation.
+function dotRadius(kind: Kind, jitter: number): number {
+  const base = kind === "strong" ? 3.5 : kind === "ok" ? 3.1 : kind === "fading" ? 2.9 : 3.2;
+  return base + jitter * 0.5;
+}
+
+function mix(n: number): number {
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  return (n ^ (n >>> 16)) >>> 0;
+}
+
+const r2 = (v: number) => Math.round(v * 100) / 100;
+
+function buildDots(data: Scenario): Dot[] {
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const kinds: Kind[] = [];
+  for (let i = 0; i < data.dueNow; i++) kinds.push("asleep");
+  for (let i = 0; i < data.counts.new; i++) kinds.push("new");
+  while (kinds.length < total) {
+    const s = mix(hash(`${data.key}k${kinds.length}`)) % 100;
+    kinds.push(s > 55 ? "strong" : s > 18 ? "ok" : "fading");
+  }
+
+  // Continuous position within the zone. A golden-ratio sequence spreads
+  // words evenly across their zone (random x leaves gaps → streaky towers);
+  // a pinch of hash jitter keeps it from feeling mechanical.
+  const perKind: Record<string, number> = {};
+  const swarm = kinds
+    .map((kind, i) => {
+      if (kind === "new") return null;
+      const k = (perKind[kind] = (perKind[kind] ?? 0) + 1);
+      const jitter = ((mix(hash(`${data.key}x${i}`)) % 100) / 100 - 0.5) * 0.06;
+      const t = Math.min(0.999, Math.max(0.001, ((k * 0.618034) % 1) + jitter));
+      const [z0, z1] = ZONES[kind];
+      return { i, kind, x: X0 + (z0 + t * (z1 - z0)) * (X1 - X0) };
+    })
+    .filter((d): d is { i: number; kind: Kind; x: number } => d !== null);
+
+  // Gravity packing: each word falls at its x and rests on the ground or
+  // nestles on whatever is already there — the vocabulary piles into dunes
+  // instead of seating-plan rows.
+  const placed: { x: number; y: number; r: number }[] = [];
+  const packed: Dot[] = swarm.map((d) => {
+    const jitter = (mix(hash(`${data.key}r${d.i}`)) % 100) / 100;
+    const r = dotRadius(d.kind, jitter);
+    let y = GROUND - r;
+    for (const p of placed) {
+      const dx = p.x - d.x;
+      const gap = p.r + r + PAD;
+      if (Math.abs(dx) < gap) {
+        const rest = p.y - Math.sqrt(gap * gap - dx * dx);
+        if (rest < y) y = rest;
+      }
+    }
+    placed.push({ x: d.x, y, r });
+    const [arabizi, english] = VOCAB_LOOKUP[d.i % VOCAB_LOOKUP.length];
+    return { i: d.i, arabizi, english, kind: d.kind, x: r2(d.x), y: r2(y), r: r2(r) };
+  });
+
+  return packed;
+}
+
+export function DriftVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  // Hover previews (sticky, so the cursor can travel to the quiz button);
+  // click/tap pins — the only path on touch, where the panel actually ships.
+  const [pin, setPin] = useState<Dot | null>(null);
+  const [hover, setHover] = useState<Dot | null>(null);
+  const sel = pin ?? hover;
+  const dots = buildDots(data);
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+
+  const zoneLabels: { key: Exclude<Kind, "new">; label: string; tone: string }[] = [
+    { key: "asleep", label: `asleep ${data.dueNow}`, tone: data.dueNow > 20 ? "#b45309" : "#9ca3af" },
+    { key: "fading", label: "fading", tone: "#9ca3af" },
+    { key: "ok", label: "settled", tone: "#9ca3af" },
+    { key: "strong", label: "solid", tone: "#9ca3af" },
+  ];
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${total} words`}>Memory drift</Eyebrow>
+      </div>
+      <div className="px-1 pt-1">
+        <svg
+          viewBox="0 0 288 158"
+          className="w-full block"
+          role="img"
+          aria-label={`Memory drift: ${data.dueNow} words asleep, drifting right as they strengthen`}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setPin(null);
+              setHover(null);
+            }
+          }}
+        >
+          {/* the ground everything rests on */}
+          <line x1={X0 - 4} x2={X1 + 4} y1={GROUND + 1.5} y2={GROUND + 1.5} stroke="#e5e7eb" strokeWidth={1} />
+          {/* the due line: everything left of it needs you */}
+          <line
+            x1={X0 + 0.295 * (X1 - X0)}
+            x2={X0 + 0.295 * (X1 - X0)}
+            y1={34}
+            y2={GROUND + 1.5}
+            stroke={data.dueNow > 0 ? "#fca5a5" : "#e5e7eb"}
+            strokeWidth={1}
+            strokeDasharray="2 4"
+          />
+          {dots.map((d) => {
+            const selected = sel?.i === d.i;
+            const dimmed = sel !== null && !selected;
+            return (
+              <circle
+                key={`${data.key}-${d.i}`}
+                cx={d.x}
+                cy={d.y}
+                r={selected ? d.r + 1.8 : d.r}
+                fill={KIND_FILL[d.kind]}
+                stroke={d.kind === "asleep" ? (selected ? "#b45309" : "#d1d5db") : selected ? "#111827" : "none"}
+                strokeWidth={d.kind === "asleep" ? 1.2 : selected ? 1.6 : 0}
+                className="cursor-pointer lab-settle"
+                style={{
+                  opacity: dimmed ? 0.2 : undefined,
+                  transition: "opacity 200ms ease",
+                  animationDelay: `${(mix(hash(`${data.key}d${d.i}`)) % 20) * 30}ms`,
+                }}
+                onMouseEnter={() => setHover(d)}
+                onClick={() => setPin(pin?.i === d.i ? null : d)}
+              />
+            );
+          })}
+          {/* zone labels along the baseline */}
+          {zoneLabels.map(({ key, label, tone }) => {
+            const [z0, z1] = ZONES[key];
+            return (
+              <text
+                key={key}
+                x={r2(X0 + ((z0 + z1) / 2) * (X1 - X0))}
+                y={150}
+                fontSize={8}
+                fontFamily="var(--font-geist-mono)"
+                fill={tone}
+                fontWeight={key === "asleep" && data.dueNow > 20 ? 700 : 400}
+                textAnchor="middle"
+              >
+                {label}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="h-[52px] mx-3 mb-2.5 mt-1">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">{KIND_LABEL[sel.kind]}</div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span>
+              reviews push words <span className="text-heading font-semibold">→ right</span>; neglect pulls
+              them <span className={cn("font-semibold", data.dueNow > 20 ? "text-amber-600" : "text-heading")}>← left</span>
+            </span>
+            <span className="ml-auto text-disabled shrink-0">hover or tap a dot</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/EssayVariant.tsx
+++ b/app/design-lab/EssayVariant.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+// Variant Q — "The essay"
+// Pudding technique #1: the data lives inside the prose. The hero is a
+// tiny visual essay — an editorial lede in PP Hatton, then a sentence
+// where the numbers are typeset as data and the at-risk words appear
+// inline as tappable ghosts. Reads like the opening of a story about you.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, sampleVocab, weakestFirst, minutesFor } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, DetailRow, type SpotWord } from "./chassis";
+
+function Num({ value, tone }: { value: number; tone?: "amber" | "green" }) {
+  return (
+    <span
+      className={cn(
+        "font-mono font-semibold tabular-nums px-1 py-0.5 rounded",
+        tone === "amber" ? "bg-amber-50 text-amber-700" : tone === "green" ? "bg-green-50 text-green-700" : "text-heading"
+      )}
+    >
+      {value}
+    </span>
+  );
+}
+
+export function EssayVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [sel, setSel] = useState<SpotWord | null>(null);
+  const isBacklog = data.dueNow > 20;
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  // The three most-recently-slipped words, named in the prose itself.
+  const ghosts: SpotWord[] = (isBacklog
+    ? weakestFirst(data.words).filter((w) => w.dueInDays < -0.5).slice(-3)
+    : weakestFirst(data.words).slice(0, 3)
+  ).map((w) => ({
+    arabizi: w.arabizi,
+    english: w.english,
+    note: isBacklog ? `slipped ${Math.round(-w.dueInDays)} days ago` : "your weakest right now",
+  }));
+  const fresh = sampleVocab(2, `${data.key}essay`);
+
+  const GhostWord = ({ w }: { w: SpotWord }) => (
+    <button
+      onMouseEnter={() => setSel(w)}
+      onClick={() => setSel(w)}
+      className={cn(
+        "italic rounded-sm transition-[filter,opacity,color] duration-300",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
+        sel?.arabizi === w.arabizi
+          ? "text-green-700 opacity-100 blur-0"
+          : isBacklog
+          ? "text-gray-500 opacity-40 blur-[1.2px]"
+          : "text-amber-700 opacity-80 blur-[0.4px]"
+      )}
+    >
+      {w.arabizi}
+    </button>
+  );
+
+  const hero = (
+    <Card onMouseLeave={() => setSel(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right="your story so far">Chapter {isBacklog ? "2: the quiet" : "3: the streak"}</Eyebrow>
+      </div>
+      <div className="px-4 pt-3 pb-1">
+        <h3 className="font-title font-medium text-[19px] leading-snug text-heading">
+          {isBacklog ? "Your Lebanese went quiet in July." : "Your Lebanese is wide awake."}
+        </h3>
+        <p className="mt-2.5 text-[13px] leading-[1.75] text-body">
+          You&apos;ve met <Num value={total} /> words so far.{" "}
+          {isBacklog ? (
+            <>
+              <Num value={total - data.dueNow - data.counts.new} tone="green" /> are still holding on — but{" "}
+              <Num value={data.dueNow} tone="amber" /> went quiet while you were away, most recently{" "}
+              <GhostWord w={ghosts[0]} />, <GhostWord w={ghosts[1]} /> and <GhostWord w={ghosts[2]} />.
+            </>
+          ) : (
+            <>
+              <Num value={data.counts.learned} tone="green" /> are solid, your streak is{" "}
+              <Num value={data.streak} /> days old, and only <GhostWord w={ghosts[0]} />,{" "}
+              <GhostWord w={ghosts[1]} /> and <GhostWord w={ghosts[2]} /> are wobbling.
+            </>
+          )}
+        </p>
+        <p className="mt-2 text-[13px] leading-[1.75] text-body">
+          {isBacklog ? (
+            <>
+              The good news: <Num value={10} /> words and{" "}
+              <span className="font-medium text-heading">{minutesFor(10)} minutes</span> turn the page.
+            </>
+          ) : (
+            <>
+              Tonight&apos;s chapter: <Num value={Math.max(data.dueNow, 3)} /> quick words — then maybe meet{" "}
+              <span className="italic text-subtle">{fresh[0][0]}</span> and{" "}
+              <span className="italic text-subtle">{fresh[1][0]}</span>?
+            </>
+          )}
+        </p>
+      </div>
+      <DetailRow
+        word={sel}
+        onAction={onAction}
+        hint={
+          <>
+            <span>
+              the numbers are live — and the <span className="italic">italic ghosts</span> are real words
+            </span>
+            <span className="ml-auto text-disabled shrink-0">tap one</span>
+          </>
+        }
+      />
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/FeedbackOverlay.tsx
+++ b/app/design-lab/FeedbackOverlay.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+// Figma-style feedback overlay for the design lab. Click "Add feedback",
+// click any element inside a variant, type a note. "Submit all" formats
+// everything as markdown and copies it to the clipboard to paste back into
+// the Claude session. Self-contained on purpose — deleted with the lab.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Comment {
+  id: number;
+  variant: string;
+  selector: string;
+  description: string;
+  text: string;
+}
+
+function describeElement(el: Element): string {
+  const tag = el.tagName.toLowerCase();
+  const text = (el.textContent ?? "").trim().replace(/\s+/g, " ").slice(0, 40);
+  return text ? `${tag} with "${text}"` : tag;
+}
+
+function selectorFor(el: Element): string {
+  if (el.id) return `#${el.id}`;
+  const testId = el.getAttribute("data-testid");
+  if (testId) return `[data-testid='${testId}']`;
+  const cls = Array.from(el.classList)
+    .filter((c) => !c.startsWith("hover:") && !c.startsWith("focus"))
+    .slice(0, 2)
+    .join(".");
+  return cls ? `${el.tagName.toLowerCase()}.${cls}` : el.tagName.toLowerCase();
+}
+
+export function FeedbackOverlay({ targetName }: { targetName: string }) {
+  const [picking, setPicking] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [direction, setDirection] = useState("");
+  const [draft, setDraft] = useState<{ variant: string; selector: string; description: string } | null>(null);
+  const [draftText, setDraftText] = useState("");
+  const [copied, setCopied] = useState(false);
+  const nextId = useRef(1);
+  const hovered = useRef<HTMLElement | null>(null);
+
+  const clearHighlight = useCallback(() => {
+    if (hovered.current) {
+      hovered.current.style.outline = "";
+      hovered.current.style.outlineOffset = "";
+      hovered.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!picking) return;
+
+    const onMove = (e: MouseEvent) => {
+      const el = e.target as HTMLElement;
+      if (el.closest("[data-feedback-ui]") || !el.closest("[data-variant]")) {
+        clearHighlight();
+        return;
+      }
+      if (hovered.current !== el) {
+        clearHighlight();
+        hovered.current = el;
+        el.style.outline = "2px solid #7c3aed";
+        el.style.outlineOffset = "2px";
+      }
+    };
+
+    const onClick = (e: MouseEvent) => {
+      const el = e.target as HTMLElement;
+      if (el.closest("[data-feedback-ui]")) return;
+      const variantEl = el.closest("[data-variant]");
+      if (!variantEl) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setDraft({
+        variant: variantEl.getAttribute("data-variant") ?? "?",
+        selector: selectorFor(el),
+        description: describeElement(el),
+      });
+      setDraftText("");
+      setPicking(false);
+      clearHighlight();
+    };
+
+    document.addEventListener("mousemove", onMove, true);
+    document.addEventListener("click", onClick, true);
+    return () => {
+      document.removeEventListener("mousemove", onMove, true);
+      document.removeEventListener("click", onClick, true);
+      clearHighlight();
+    };
+  }, [picking, clearHighlight]);
+
+  const saveDraft = () => {
+    if (!draft || !draftText.trim()) return;
+    setComments((c) => [...c, { id: nextId.current++, ...draft, text: draftText.trim() }]);
+    setDraft(null);
+    setDraftText("");
+    setPanelOpen(true);
+  };
+
+  const submit = async () => {
+    const byVariant = new Map<string, Comment[]>();
+    for (const c of comments) {
+      byVariant.set(c.variant, [...(byVariant.get(c.variant) ?? []), c]);
+    }
+    let md = `## Design Lab Feedback\n\n**Target:** ${targetName}\n**Comments:** ${comments.length}\n`;
+    for (const [variant, list] of [...byVariant.entries()].sort()) {
+      md += `\n### Variant ${variant}\n`;
+      list.forEach((c, i) => {
+        md += `${i + 1}. **Element** (\`${c.selector}\`, ${c.description})\n   "${c.text}"\n`;
+      });
+    }
+    md += `\n### Overall Direction\n${direction.trim() || "(not specified)"}\n`;
+    try {
+      await navigator.clipboard.writeText(md);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // clipboard blocked — show the text so it can be copied manually
+      window.prompt("Copy this feedback:", md);
+    }
+  };
+
+  return (
+    <div data-feedback-ui="true">
+      {/* picking hint */}
+      {picking && (
+        <div className="fixed top-3 left-1/2 -translate-x-1/2 z-[70] rounded-full bg-violet-600 text-white text-xs font-medium px-4 py-2 shadow-lg">
+          Click any element inside a variant to comment — Esc to cancel
+        </div>
+      )}
+
+      {/* comment draft dialog */}
+      {draft && (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/30 p-4">
+          <div className="w-full max-w-sm rounded-xl bg-white shadow-xl p-4">
+            <div className="text-xs text-gray-500">
+              Variant {draft.variant} · <code className="text-[11px]">{draft.selector}</code>
+            </div>
+            <div className="text-sm font-medium text-gray-900 mt-0.5">{draft.description}</div>
+            <textarea
+              autoFocus
+              value={draftText}
+              onChange={(e) => setDraftText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) saveDraft();
+                if (e.key === "Escape") setDraft(null);
+              }}
+              placeholder="What should change here?"
+              rows={3}
+              className="mt-3 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+            />
+            <div className="mt-3 flex justify-end gap-2">
+              <button onClick={() => setDraft(null)} className="px-3 py-1.5 text-sm text-gray-600 rounded-lg hover:bg-gray-100">
+                Cancel
+              </button>
+              <button
+                onClick={saveDraft}
+                disabled={!draftText.trim()}
+                className="px-3 py-1.5 text-sm font-medium text-white bg-violet-600 rounded-lg hover:bg-violet-700 disabled:opacity-40"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* panel */}
+      {panelOpen && (
+        <div className="fixed bottom-20 right-4 z-[60] w-[340px] max-h-[60vh] flex flex-col rounded-xl bg-white border border-gray-200 shadow-2xl">
+          <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between">
+            <span className="text-sm font-semibold text-gray-900">Feedback ({comments.length})</span>
+            <button onClick={() => setPanelOpen(false)} className="text-gray-400 hover:text-gray-600 text-lg leading-none">
+              ×
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-4 py-2">
+            {comments.length === 0 && <p className="text-xs text-gray-500 py-2">No comments yet — use “Add feedback”.</p>}
+            {comments.map((c) => (
+              <div key={c.id} className="py-2 border-b border-gray-50 last:border-0">
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] font-mono text-violet-600">Variant {c.variant} · {c.description}</span>
+                  <button
+                    onClick={() => setComments((cs) => cs.filter((x) => x.id !== c.id))}
+                    className="text-gray-300 hover:text-red-500 text-xs"
+                    aria-label="Delete comment"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <p className="text-xs text-gray-800 mt-0.5">{c.text}</p>
+              </div>
+            ))}
+          </div>
+          <div className="px-4 py-3 border-t border-gray-100">
+            <textarea
+              value={direction}
+              onChange={(e) => setDirection(e.target.value)}
+              placeholder="Overall direction (required) — e.g. 'B's forest + A's recovery plan'"
+              rows={2}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-violet-500"
+            />
+            <button
+              onClick={submit}
+              disabled={!direction.trim() && comments.length === 0}
+              className="mt-2 w-full py-2 rounded-lg bg-violet-600 text-white text-sm font-medium hover:bg-violet-700 disabled:opacity-40"
+            >
+              {copied ? "✓ Copied — paste it to Claude" : "Submit all feedback (copies to clipboard)"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* launcher buttons */}
+      <div className="fixed bottom-4 right-4 z-[60] flex gap-2">
+        <button
+          onClick={() => setPanelOpen((o) => !o)}
+          className="rounded-full bg-white border border-gray-200 shadow-lg px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          💬 {comments.length}
+        </button>
+        <button
+          onClick={() => setPicking((p) => !p)}
+          className={`rounded-full shadow-lg px-4 py-2.5 text-sm font-semibold ${
+            picking ? "bg-violet-100 text-violet-700 border border-violet-300" : "bg-violet-600 text-white hover:bg-violet-700"
+          }`}
+        >
+          {picking ? "Cancel" : "＋ Add feedback"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/design-lab/FieldVariant.tsx
+++ b/app/design-lab/FieldVariant.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+// Variant F — "Memory field"
+// Signature: the entire vocabulary as one dense, tappable dot-matrix.
+// Fill = memory strength, hollow rings = asleep (overdue), small gray = not
+// started. Dots settle in with a staggered entrance; selecting one dims the
+// rest of the field to spotlight it. A backlog reads as a field gone quiet,
+// not a wall of red.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, VOCAB_LOOKUP } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, hash } from "./chassis";
+
+type Dot = {
+  i: number;
+  arabizi: string;
+  english: string;
+  kind: "strong" | "ok" | "fading" | "asleep" | "new";
+};
+
+const KIND_FILL: Record<Dot["kind"], string> = {
+  strong: "#15803d",
+  ok: "#4ade80",
+  fading: "#f59e0b",
+  asleep: "none",
+  new: "#e5e7eb",
+};
+
+const KIND_LABEL: Record<Dot["kind"], string> = {
+  strong: "solid — long time till review",
+  ok: "settled",
+  fading: "fading — review soon",
+  asleep: "asleep — needs a review",
+  new: "not started yet",
+};
+
+function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b);
+}
+
+function buildDots(data: Scenario): Dot[] {
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  // Build the kind pool, then scatter it with a coprime stride so asleep
+  // dots weave through the field instead of forming a block.
+  const kinds: Dot["kind"][] = [];
+  for (let i = 0; i < data.dueNow; i++) kinds.push("asleep");
+  for (let i = 0; i < data.counts.new; i++) kinds.push("new");
+  while (kinds.length < total) {
+    const s = hash(`${data.key}s${kinds.length}`) % 100;
+    kinds.push(s > 55 ? "strong" : s > 20 ? "ok" : "fading");
+  }
+  let stride = 73;
+  while (gcd(stride, total) !== 1) stride += 2;
+  const dots: Dot[] = new Array(total);
+  for (let i = 0; i < total; i++) {
+    const pos = (i * stride + 11) % total;
+    const [arabizi, english] = VOCAB_LOOKUP[pos % VOCAB_LOOKUP.length];
+    dots[pos] = { i: pos, arabizi, english, kind: kinds[i] };
+  }
+  return dots;
+}
+
+export function FieldVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  // Hover previews (sticky, so the cursor can travel to the quiz button);
+  // click/tap pins — the only path on touch, where the panel actually ships.
+  const [pin, setPin] = useState<Dot | null>(null);
+  const [hover, setHover] = useState<Dot | null>(null);
+  const sel = pin ?? hover;
+  const dots = buildDots(data);
+  const cols = 20;
+  const cell = 288 / cols;
+  const rows = Math.ceil(dots.length / cols);
+  const height = rows * cell + 8;
+  const awake = dots.length - data.dueNow - data.counts.new;
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${dots.length} words`}>Memory field</Eyebrow>
+      </div>
+      <div className="px-3 pt-2.5">
+        <svg
+          viewBox={`0 0 288 ${height}`}
+          className="w-full block"
+          role="img"
+          aria-label={`Memory field: ${awake} words awake, ${data.dueNow} asleep, ${data.counts.new} new`}
+          onClick={(e) => {
+            // tap empty space to release the spotlight
+            if (e.target === e.currentTarget) {
+              setPin(null);
+              setHover(null);
+            }
+          }}
+        >
+          {dots.map((d, idx) => {
+            // Hand-planted, not machine-stamped: each dot sits slightly off
+            // its grid cell, with a whisper of size variation.
+            const jx = ((hash(`${data.key}jx${d.i}`) % 100) / 100 - 0.5) * 4.6;
+            const jy = ((hash(`${data.key}jy${d.i}`) % 100) / 100 - 0.5) * 4.6;
+            const x = Math.round(((idx % cols) * cell + cell / 2 + jx) * 100) / 100;
+            const y = Math.round((Math.floor(idx / cols) * cell + cell / 2 + 4 + jy) * 100) / 100;
+            const size = 3.2 + ((hash(`${data.key}jr${d.i}`) % 100) / 100) * 0.7;
+            const selected = sel?.i === d.i;
+            const dimmed = sel !== null && !selected;
+            return (
+              <circle
+                key={`${data.key}-${d.i}`}
+                cx={x}
+                cy={y}
+                r={d.kind === "new" ? 2 : selected ? 5.2 : Math.round(size * 100) / 100}
+                fill={KIND_FILL[d.kind]}
+                stroke={d.kind === "asleep" ? (selected ? "#b45309" : "#d1d5db") : selected ? "#111827" : "none"}
+                strokeWidth={d.kind === "asleep" ? 1.2 : selected ? 1.6 : 0}
+                className="cursor-pointer lab-settle"
+                style={{
+                  opacity: dimmed ? 0.22 : undefined,
+                  transition: "opacity 200ms ease, r 150ms ease",
+                  animationDelay: `${(hash(`${data.key}in${d.i}`) % 24) * 28}ms`,
+                }}
+                onMouseEnter={() => setHover(d)}
+                onClick={() => setPin(pin?.i === d.i ? null : d)}
+              />
+            );
+          })}
+        </svg>
+      </div>
+      <div className="h-[52px] mx-3 mb-2.5 mt-1.5">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">{KIND_LABEL[sel.kind]}</div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-green-600 inline-block" />
+              awake <span className="tabular-nums">{awake}</span>
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full border border-gray-300 inline-block" />
+              asleep <span className={cn("tabular-nums", data.dueNow > 20 && "text-amber-600 font-semibold")}>{data.dueNow}</span>
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-200 inline-block" />
+              new <span className="tabular-nums">{data.counts.new}</span>
+            </span>
+            <span className="ml-auto text-disabled">hover or tap a dot</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/FinalVariant.tsx
+++ b/app/design-lab/FinalVariant.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+// Variant V — the synthesis (P + Q + T)
+// P's folded page is the body: your words in memory order, weight-first
+// fade, an amber fold where the asleep ones begin. Q's voice tells it:
+// every beat is a sentence where the data lives in the prose. T's beats
+// structure it: three readings of the same page — what you built, what
+// the forgetting curve took, and the sweet-spot catch that brings it back.
+// Tone: Nicky Case's memory explainer — science, warmly delivered.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, sampleKinds, sampleVocab, seeded, minutesFor, type SampleKind } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, DetailRow, type SpotWord } from "./chassis";
+
+type Item = { i: number; arabizi: string; english: string; kind: SampleKind };
+
+const KIND_ORDER: Record<SampleKind, number> = { strong: 0, ok: 1, fading: 2, asleep: 3 };
+
+const BASE_STYLE: Record<SampleKind, string> = {
+  strong: "font-semibold text-gray-900",
+  ok: "font-normal text-gray-800 opacity-90",
+  fading: "font-light text-gray-600 opacity-70 blur-[0.4px]",
+  asleep: "font-light text-gray-500 opacity-35 blur-[1.4px]",
+};
+
+const KIND_LABEL: Record<SampleKind, string> = {
+  strong: "bold in your memory — the curve is flat here",
+  ok: "settled",
+  fading: "near the sweet spot — catch it soon",
+  asleep: "crossed the curve — one review wakes it",
+};
+
+const SHOWN = 40;
+
+function Num({ value, tone }: { value: number | string; tone?: "amber" | "green" }) {
+  return (
+    <span
+      className={cn(
+        "font-mono font-semibold tabular-nums px-1 py-0.5 rounded",
+        tone === "amber" ? "bg-amber-50 text-amber-700" : tone === "green" ? "bg-green-50 text-green-700" : "text-heading"
+      )}
+    >
+      {value}
+    </span>
+  );
+}
+
+function buildItems(data: Scenario): Item[] {
+  const kinds = sampleKinds(data, SHOWN, "final");
+  const vocab = sampleVocab(SHOWN, `${data.key}finalv`);
+  return kinds
+    .map((kind, i) => ({ i, arabizi: vocab[i % vocab.length][0], english: vocab[i % vocab.length][1], kind }))
+    .sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || seeded(`${data.key}fo${a.i}`) - seeded(`${data.key}fo${b.i}`));
+}
+
+export function FinalVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [beat, setBeat] = useState(0);
+  const [pin, setPin] = useState<Item | null>(null);
+  const [hover, setHover] = useState<Item | null>(null);
+  const sel = pin ?? hover;
+
+  const isBacklog = data.dueNow > 20;
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const items = buildItems(data);
+  const foldAt = items.findIndex((it) => it.kind === "asleep");
+  const rescue = items.filter((it) => it.kind === "asleep").slice(0, 3);
+  const bite = Math.min(10, Math.max(1, data.dueNow));
+
+  const GhostInline = ({ it }: { it: Item }) => (
+    <button
+      onMouseEnter={() => setHover(it)}
+      onClick={() => setPin(pin?.i === it.i ? null : it)}
+      className={cn(
+        "italic rounded-sm transition-[filter,opacity,color] duration-300",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500",
+        sel?.i === it.i ? "text-green-700 opacity-100 blur-0" : "text-gray-500 opacity-45 blur-[0.9px]"
+      )}
+    >
+      {it.arabizi}
+    </button>
+  );
+
+  // Three readings of the same page, in the explainer's voice.
+  const beats = [
+    {
+      lede: `You've planted ${total} words in your head.`,
+      prose: (
+        <>
+          This page is all of them, loudest first — <span className="font-semibold text-heading">bold</span>{" "}
+          means the memory is solid. And here&apos;s the thing: every single one is quietly decaying right
+          now. Not a you-problem. Brains just do that.
+        </>
+      ),
+      style: (kind: SampleKind) => BASE_STYLE[kind],
+    },
+    {
+      lede: isBacklog ? "Then the forgetting curve did its thing." : "The forgetting curve is losing, for once.",
+      prose: isBacklog ? (
+        <>
+          While you were away, <Num value={data.dueNow} tone="amber" /> words slid past the point of easy
+          recall. They&apos;re not gone — they&apos;re asleep below the fold. The blur you&apos;re seeing is
+          your actual recall, rendered.
+        </>
+      ) : (
+        <>
+          Only <Num value={data.dueNow} tone="amber" /> words are anywhere near the edge. Everything else is
+          holding — this is what being ahead of the curve looks like.
+        </>
+      ),
+      style: (kind: SampleKind) =>
+        kind === "asleep" ? "font-light text-gray-500 opacity-45 blur-[1.2px]" : "font-light text-gray-400 opacity-40",
+    },
+    {
+      lede: "Catch a word at the sweet spot, and the fade slows.",
+      prose: (
+        <>
+          Review a word right as it slips and its decay curve flattens — days become weeks become months.{" "}
+          {rescue.length > 0 ? (
+            <>
+              Start with <GhostInline it={rescue[0]} />
+              {rescue[1] && (
+                <>
+                  {", "}
+                  <GhostInline it={rescue[1]} />
+                </>
+              )}
+              {rescue[2] && (
+                <>
+                  {" and "}
+                  <GhostInline it={rescue[2]} />
+                </>
+              )}
+              {" — "}
+              <Num value={`${minutesFor(bite)} min`} tone="green" /> buys them back.
+            </>
+          ) : (
+            <>Nothing is slipping right now — plant something new instead.</>
+          )}
+        </>
+      ),
+      style: (kind: SampleKind, i: number) =>
+        rescue.some((r) => r.i === i)
+          ? "font-semibold text-green-700 opacity-100"
+          : kind === "asleep"
+          ? "font-light text-gray-400 opacity-25 blur-[1.4px]"
+          : "font-light text-gray-400 opacity-35",
+    },
+  ];
+
+  const word = (it: Item) => {
+    const selected = sel?.i === it.i;
+    return (
+      <button
+        key={it.i}
+        onMouseEnter={() => setHover(it)}
+        onClick={() => setPin(pin?.i === it.i ? null : it)}
+        aria-label={`${it.arabizi} — ${KIND_LABEL[it.kind]}`}
+        className={cn(
+          "text-[13px] leading-6 rounded-sm transition-all duration-500",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+          selected ? "font-semibold text-green-700 opacity-100 blur-0" : beats[beat].style(it.kind, it.i)
+        )}
+      >
+        {it.arabizi}
+      </button>
+    );
+  };
+
+  const foldEmphasis = beat === 1;
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${beat + 1} / 3`}>How your memory is doing</Eyebrow>
+      </div>
+      {/* the voice (Q): lede + data-in-prose */}
+      <div className="px-4 pt-2.5 min-h-[104px]">
+        <h3 className="font-title font-medium text-[18px] leading-snug text-heading">{beats[beat].lede}</h3>
+        <p className="mt-1.5 text-[12.5px] leading-[1.7] text-body">{beats[beat].prose}</p>
+      </div>
+      {/* the body (P): the folded page, restyled per beat (T) */}
+      <div className="px-4 pt-2.5 pb-1 select-none">
+        <div className="flex flex-wrap items-baseline gap-x-[9px] gap-y-[2px]">
+          {(foldAt === -1 ? items : items.slice(0, foldAt)).map(word)}
+          {foldAt !== -1 && (
+            <>
+              <div className="w-full flex items-center gap-2 my-1.5 transition-opacity duration-500" aria-hidden="true">
+                <span className={cn("flex-1 border-t border-dashed", foldEmphasis ? "border-amber-400" : "border-amber-300")} />
+                <span className={cn("font-mono text-[9px] tracking-[0.1em]", foldEmphasis ? "text-amber-700 font-semibold" : "text-amber-600")}>
+                  THE FOLD · {data.dueNow} ASLEEP BELOW
+                </span>
+                <span className={cn("flex-1 border-t border-dashed", foldEmphasis ? "border-amber-400" : "border-amber-300")} />
+              </div>
+              {items.slice(foldAt).map(word)}
+            </>
+          )}
+        </div>
+      </div>
+      {/* the beats (T): pager + forward momentum */}
+      <div className="px-4 pt-1.5 flex items-center gap-2">
+        {[0, 1, 2].map((b) => (
+          <button
+            key={b}
+            onClick={() => setBeat(b)}
+            aria-label={`Part ${b + 1}`}
+            aria-current={beat === b}
+            style={{ height: 6 }}
+            className={cn(
+              "rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+              beat === b ? "w-8 bg-green-600" : "w-6 bg-gray-200 hover:bg-gray-300"
+            )}
+          />
+        ))}
+        <button
+          onClick={() =>
+            beat < 2
+              ? setBeat(beat + 1)
+              : onAction(
+                  isBacklog ? `Start a rescue session with my ${bite} weakest words` : data.dueNow > 0 ? `Review my ${data.dueNow} due words` : "Teach me 3 new words"
+                )
+          }
+          className="ml-auto h-8 px-3 rounded-lg text-xs font-semibold text-green-700 hover:bg-green-50 active:bg-green-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+        >
+          {beat < 2 ? "so?  →" : "yalla →"}
+        </button>
+      </div>
+      <DetailRow
+        word={sel ? ({ arabizi: sel.arabizi, english: sel.english, note: KIND_LABEL[sel.kind] } satisfies SpotWord) : null}
+        onAction={onAction}
+        hint={
+          <>
+            <span>same page, three readings — the blur is your real recall</span>
+            <span className="ml-auto text-disabled shrink-0">hover or tap a word</span>
+          </>
+        }
+      />
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/FoldVariant.tsx
+++ b/app/design-lab/FoldVariant.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+// Variant P — "The fold"
+// The synthesis of the fading page (L) and word drift (N): one flowing page
+// of words ordered strongest → weakest, so reading order IS the memory axis.
+// Fading uses font weight first (a precise typographic channel — Brath,
+// "Visualizing with Text"), opacity second, blur last and capped so ghosts
+// stay clearly intentional. Where the asleep words begin, the page folds:
+// a labeled rule — everything below it is waiting for you.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, sampleVocab, seeded, type SampleKind } from "./fixtures";
+import { Card, Eyebrow, MissionChassis } from "./chassis";
+
+type Item = { i: number; arabizi: string; english: string; kind: SampleKind };
+
+const KIND_ORDER: Record<SampleKind, number> = { strong: 0, ok: 1, fading: 2, asleep: 3 };
+
+const KIND_STYLE: Record<SampleKind, string> = {
+  strong: "font-semibold text-gray-900",
+  ok: "font-normal text-gray-800 opacity-90",
+  fading: "font-light text-gray-600 opacity-70 blur-[0.4px]",
+  asleep: "font-light text-gray-500 opacity-35 blur-[1.4px]",
+};
+
+const KIND_LABEL: Record<SampleKind, string> = {
+  strong: "bold in your memory",
+  ok: "settled",
+  fading: "losing weight — review soon",
+  asleep: "below the fold — review to lift it back",
+};
+
+const SHOWN = 48;
+
+function buildItems(data: Scenario): Item[] {
+  // Curated, not proportional: the words that need you get guaranteed slots.
+  // With 1000 learned and 3 due, a proportional sample would show a wall of
+  // solid words and bury the 3 that matter — instead, every due word (up to
+  // a cap) makes the page, and the strong ones fill the rest as backdrop.
+  const asleepSlots = Math.min(data.dueNow, 16);
+  const rest = SHOWN - asleepSlots;
+  const kinds: SampleKind[] = [];
+  for (let i = 0; i < asleepSlots; i++) kinds.push("asleep");
+  for (let i = 0; i < rest; i++) {
+    const s = seeded(`${data.key}foldk${i}`) % 100;
+    kinds.push(s > 50 ? "strong" : s > 16 ? "ok" : "fading");
+  }
+  const vocab = sampleVocab(SHOWN, `${data.key}foldv`);
+  const items = kinds.map((kind, i) => {
+    const [arabizi, english] = vocab[i % vocab.length];
+    return { i, arabizi, english, kind };
+  });
+  // Reading order is the axis: strongest ink first, ghosts last.
+  return items.sort(
+    (a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || seeded(`${data.key}o${a.i}`) - seeded(`${data.key}o${b.i}`)
+  );
+}
+
+export function FoldVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  // Hover previews; click sends the quiz prompt to the tutor immediately.
+  const [hover, setHover] = useState<Item | null>(null);
+  const sel = hover;
+  const items = buildItems(data);
+  const foldAt = items.findIndex((it) => it.kind === "asleep");
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+
+  const word = (it: Item) => {
+    return (
+      <button
+        key={it.i}
+        onMouseEnter={() => setHover(it)}
+        onClick={() => onAction(`Quiz me on "${it.arabizi}"`)}
+        aria-label={`Quiz me on ${it.arabizi} — ${KIND_LABEL[it.kind]}`}
+        className={cn(
+          // Padding (not flex gap) provides the spacing, so hover targets
+          // tile with no dead space; scale (not weight) grows the word in
+          // place, so lines never re-wrap.
+          "inline-block px-[4.5px] py-[2px] text-[13.5px] leading-6 rounded-sm origin-center relative",
+          "transition-[filter,opacity,color,transform] duration-200",
+          "hover:scale-[1.22] hover:opacity-100 hover:blur-0 hover:z-10 hover:text-green-700",
+          "active:scale-[1.1]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+          KIND_STYLE[it.kind]
+        )}
+      >
+        {it.arabizi}
+      </button>
+    );
+  };
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${SHOWN} of ${total}`}>Your words, strongest first</Eyebrow>
+      </div>
+      <div className="px-[11px] pt-2.5 pb-1 select-none">
+        <div className="flex flex-wrap items-baseline">
+          {(foldAt === -1 ? items : items.slice(0, foldAt)).map(word)}
+          {foldAt !== -1 && (
+            <>
+              {/* the fold: reading past this line means words need you */}
+              <div className="w-full flex items-center gap-2 my-1.5" aria-hidden="true">
+                <span className="flex-1 border-t border-dashed border-amber-300" />
+                <span className="font-mono text-[9px] tracking-[0.1em] text-amber-600">
+                  THE FOLD · {data.dueNow} ASLEEP BELOW
+                </span>
+                <span className="flex-1 border-t border-dashed border-amber-300" />
+              </div>
+              {items.slice(foldAt).map(word)}
+            </>
+          )}
+        </div>
+      </div>
+      <div className="h-[52px] mx-3 mb-2.5 mt-1.5">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">{KIND_LABEL[sel.kind]}</div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span>
+              fading in memory order — reviews lift words{" "}
+              <span className="text-heading font-semibold">back above the fold</span>
+            </span>
+            <span className="ml-auto text-disabled shrink-0">hover to peek · click to quiz</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/LedgerVariant.tsx
+++ b/app/design-lab/LedgerVariant.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+// Variant M — "Fading ledger"
+// The page, given order: your words as a ledger sorted strongest → weakest,
+// so the ink visibly runs out as you read down. It replaces the chassis'
+// "slipping first" list entirely — the hero IS the list. Real data drives
+// every row: retention % while it lasts, then "asleep Nd" as the ink goes.
+
+import { cn } from "@/lib/utils";
+import { type Scenario, type LabWord, retention, weakestFirst } from "./fixtures";
+import { Card, Eyebrow, MissionChassis } from "./chassis";
+
+const ROWS = 13;
+
+function rowStyle(r: number | null): { text: string; blur: string } {
+  if (r === null) return { text: "text-gray-400", blur: "blur-[2.2px] opacity-30" };
+  if (r > 0.75) return { text: "text-gray-900", blur: "" };
+  if (r > 0.45) return { text: "text-gray-800", blur: "blur-[0.3px] opacity-85" };
+  if (r > 0.2) return { text: "text-gray-600", blur: "blur-[0.8px] opacity-60" };
+  return { text: "text-gray-500", blur: "blur-[1.8px] opacity-35" };
+}
+
+function Row({ word, onAction }: { word: LabWord; onAction: (a: string) => void }) {
+  const r = word.reviewCount === 0 ? null : retention(word);
+  const overdue = word.dueInDays < -0.5;
+  const style = rowStyle(overdue ? 0.05 : r);
+  return (
+    <button
+      onClick={() => onAction(`Quiz me on "${word.arabizi}"`)}
+      className="w-full flex items-baseline gap-3 h-[30px] px-1.5 text-left rounded-md group hover:bg-gray-50 active:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+    >
+      <span
+        className={cn(
+          "text-[13.5px] font-medium truncate w-[92px] shrink-0 transition-[filter,opacity] duration-300 group-hover:blur-0 group-hover:opacity-100",
+          style.text,
+          style.blur
+        )}
+      >
+        {word.arabizi}
+      </span>
+      <span
+        className={cn(
+          "flex-1 min-w-0 truncate text-xs text-subtle transition-[filter,opacity] duration-300 group-hover:blur-0 group-hover:opacity-100",
+          style.blur
+        )}
+      >
+        {word.english}
+      </span>
+      {r === null && !overdue ? (
+        <span className="font-mono text-[10px] text-disabled shrink-0">new</span>
+      ) : overdue ? (
+        <span className="font-mono text-[10.5px] text-amber-600 tabular-nums shrink-0">
+          asleep {Math.round(-word.dueInDays)}d
+        </span>
+      ) : (
+        <span
+          className={cn(
+            "font-mono text-[10.5px] tabular-nums shrink-0",
+            r! > 0.75 ? "text-green-600" : r! > 0.45 ? "text-amber-500" : "text-red-500"
+          )}
+        >
+          {Math.round(r! * 100)}%
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function LedgerVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  // Strongest ink first; the fade takes over as you read down.
+  const ordered = [...weakestFirst(data.words)].reverse().filter((w) => w.reviewCount > 0 || w.dueInDays < -0.5);
+  const rows = ordered.slice(0, ROWS);
+  const hiddenAsleep = Math.max(0, data.dueNow - rows.filter((w) => w.dueInDays < -0.5).length);
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+
+  const hero = (
+    <Card>
+      <div className="px-4 pt-3 pb-1.5 border-b border-gray-100">
+        <Eyebrow right={`${total} words · hover to remember`}>The ledger</Eyebrow>
+      </div>
+      <div className="px-2.5 py-1.5">
+        {rows.map((w) => (
+          <Row key={w.id} word={w} onAction={onAction} />
+        ))}
+      </div>
+      <button
+        onClick={() => onAction("Show me all my words")}
+        className="w-full h-10 text-[11px] font-mono text-subtle border-t border-gray-100 hover:bg-gray-50 active:bg-gray-100 rounded-b-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+      >
+        {hiddenAsleep > 0 ? (
+          <>
+            …and <span className="text-amber-600 font-semibold">{hiddenAsleep} more</span> faded below the fold
+          </>
+        ) : (
+          <>see the whole ledger</>
+        )}
+      </button>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} hideWeakest />;
+}

--- a/app/design-lab/OrbitVariant.tsx
+++ b/app/design-lab/OrbitVariant.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+// Variant G — "Orbit"
+// Signature: spaced repetition made spatial. Full-circle time rings
+// (review zone / 24h / 1w / 1m+); every word is a bead on its ring that
+// falls inward as its review approaches. Orbiting words drift slowly with
+// faint motion trails; due words have landed in the center as a sunflower
+// spiral (phyllotaxis) around the count.
+
+import { useState } from "react";
+import { type Scenario, VOCAB_LOOKUP } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, hash } from "./chassis";
+
+type Sat = {
+  i: number;
+  arabizi: string;
+  english: string;
+  due: boolean;
+  x: number;
+  y: number;
+  angle: number;
+  ring: number;
+  strong: boolean;
+};
+
+const CX = 144;
+const CY = 124;
+const RINGS = [32, 62, 89, 114]; // review zone, 24h, 1w, 1m+
+
+// Round to 2 decimals so SSR and client render identical markup (raw
+// sin/cos low bits differ between environments → hydration mismatch).
+const r2 = (v: number) => Math.round(v * 100) / 100;
+
+// The plain string hash maps consecutive suffixes ("sat4" / "sat5") to
+// consecutive values, which chains satellites into near-identical spots.
+// An avalanche mix decorrelates them.
+function mix(n: number): number {
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  return (n ^ (n >>> 16)) >>> 0;
+}
+
+const GOLDEN = 2.399963; // radians — phyllotaxis angle
+
+function place(data: Scenario): Sat[] {
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const shown = Math.min(total, 96);
+  const dueShown = Math.round((data.dueNow / total) * shown);
+  const sats: Sat[] = [];
+  // Landed words: a sunflower spiral filling the review zone from its heart.
+  const spiralC = (RINGS[0] - 11) / Math.sqrt(Math.max(dueShown, 1));
+  for (let i = 0; i < dueShown; i++) {
+    const rr = 5 + spiralC * Math.sqrt(i);
+    const th = i * GOLDEN;
+    const [arabizi, english] = VOCAB_LOOKUP[i % VOCAB_LOOKUP.length];
+    sats.push({
+      i,
+      arabizi,
+      english,
+      due: true,
+      x: r2(rr * Math.cos(th)),
+      y: r2(rr * Math.sin(th)),
+      angle: th,
+      ring: 0,
+      strong: false,
+    });
+  }
+  // Orbiting words: beads sitting on their time ring.
+  for (let i = dueShown; i < shown; i++) {
+    const h = mix(hash(`${data.key}sat${i}`));
+    const angle = ((h % 3600) / 10) * (Math.PI / 180);
+    const band = (h >>> 2) % 3; // 24h / 1w / 1m+
+    const rr = RINGS[band + 1] + (((h >>> 5) % 100) / 100 - 0.5) * 5;
+    const [arabizi, english] = VOCAB_LOOKUP[i % VOCAB_LOOKUP.length];
+    sats.push({
+      i,
+      arabizi,
+      english,
+      due: false,
+      x: r2(rr * Math.cos(angle)),
+      y: r2(rr * Math.sin(angle)),
+      angle,
+      ring: rr,
+      strong: (h >>> 7) % 3 !== 0,
+    });
+  }
+  return sats;
+}
+
+// Short arc trailing each orbiting bead, in its direction of travel.
+function trailPath(s: Sat): string {
+  const a1 = s.angle - 0.3;
+  const a2 = s.angle - 0.09;
+  return `M ${r2(s.ring * Math.cos(a1))} ${r2(s.ring * Math.sin(a1))} A ${r2(s.ring)} ${r2(s.ring)} 0 0 1 ${r2(
+    s.ring * Math.cos(a2)
+  )} ${r2(s.ring * Math.sin(a2))}`;
+}
+
+export function OrbitVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  // Hover previews (sticky, so the cursor can travel to the quiz button);
+  // click/tap pins — the only path on touch, where the panel actually ships.
+  const [pin, setPin] = useState<Sat | null>(null);
+  const [hover, setHover] = useState<Sat | null>(null);
+  const sel = pin ?? hover;
+  const sats = place(data);
+  const orbiting = sats.filter((s) => !s.due);
+  const landed = sats.filter((s) => s.due);
+
+  const satCircle = (s: Sat) => {
+    const selected = sel?.i === s.i;
+    const dimmed = sel !== null && !selected;
+    return (
+      <circle
+        key={s.i}
+        cx={s.x}
+        cy={s.y}
+        r={selected ? 4.6 : s.due ? 2.3 : s.strong ? 2.9 : 2.5}
+        fill={s.due ? "#dc2626" : s.strong ? "#16a34a" : "#86bc4b"}
+        stroke={selected ? "#111827" : "none"}
+        strokeWidth={selected ? 1.5 : 0}
+        style={{ opacity: dimmed ? 0.25 : s.due || s.strong ? 1 : 0.9, transition: "opacity 200ms ease" }}
+        className="cursor-pointer"
+        onMouseEnter={() => setHover(s)}
+        onClick={() => setPin(pin?.i === s.i ? null : s)}
+      />
+    );
+  };
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right="closer = due sooner">Review orbit</Eyebrow>
+      </div>
+      <svg
+        viewBox="0 0 288 250"
+        className="w-full block"
+        role="img"
+        aria-label={`Review orbit: ${data.dueNow} words in the review zone`}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            setPin(null);
+            setHover(null);
+          }
+        }}
+      >
+        <defs>
+          <radialGradient id={`zone-${data.key}`}>
+            <stop offset="0%" stopColor={data.dueNow > 0 ? "#fecaca" : "#dcfce7"} stopOpacity={0.9} />
+            <stop offset="78%" stopColor={data.dueNow > 0 ? "#fee2e2" : "#f0fdf4"} stopOpacity={0.55} />
+            <stop offset="100%" stopColor={data.dueNow > 0 ? "#fef2f2" : "#f0fdf4"} stopOpacity={0.25} />
+          </radialGradient>
+        </defs>
+        <g transform={`translate(${CX} ${CY})`}>
+          {/* time rings */}
+          <circle r={RINGS[0]} fill={`url(#zone-${data.key})`} className={data.dueNow > 0 ? "lab-zone" : undefined} />
+          {RINGS.slice(1).map((r) => (
+            <circle key={r} r={r} fill="none" stroke="#e5e7eb" strokeWidth={1} strokeDasharray="1.5 4.5" />
+          ))}
+          {/* orbiting words drift along their rings; landed words hold still */}
+          <g className="lab-orbit" style={{ animationPlayState: sel && !sel.due ? "paused" : undefined }}>
+            {orbiting.map((s) => (
+              <path
+                key={`t${s.i}`}
+                d={trailPath(s)}
+                fill="none"
+                stroke={s.strong ? "#16a34a" : "#86bc4b"}
+                strokeWidth={1.6}
+                strokeLinecap="round"
+                opacity={sel !== null && sel.i !== s.i ? 0.08 : 0.22}
+              />
+            ))}
+            {orbiting.map(satCircle)}
+          </g>
+          {landed.map(satCircle)}
+        </g>
+        {/* due count, haloed so it stays legible over the cluster */}
+        {data.dueNow > 0 && (
+          <text
+            x={CX}
+            y={CY + 5}
+            fontSize={15}
+            fontWeight={700}
+            fontFamily="var(--font-geist-mono)"
+            fill="#dc2626"
+            stroke="#ffffff"
+            strokeWidth={4}
+            paintOrder="stroke"
+            textAnchor="middle"
+          >
+            {data.dueNow}
+          </text>
+        )}
+        {/* ring labels stacked up the top axis */}
+        {["now", "24h", "1w", "1m+"].map((label, i) => (
+          <text
+            key={label}
+            x={CX}
+            y={r2(CY - RINGS[i] - 3)}
+            fontSize={7.5}
+            fontFamily="var(--font-geist-mono)"
+            fill="#9ca3af"
+            stroke="#ffffff"
+            strokeWidth={2.5}
+            paintOrder="stroke"
+            textAnchor="middle"
+          >
+            {label}
+          </text>
+        ))}
+      </svg>
+      <div className="h-[52px] mx-3 mb-2.5 mt-0.5">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">
+                {sel.due ? "landed — in the review zone now" : "in orbit — comes due later"}
+              </div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-red-600 inline-block" />
+              due <span className="tabular-nums">{data.dueNow}</span>
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-green-600 inline-block" />
+              in orbit
+            </span>
+            <span className="ml-auto text-disabled">hover or tap a word</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/PageVariant.tsx
+++ b/app/design-lab/PageVariant.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+// Variant L — "Fading page"
+// The most literal answer to "can I see my memory fading?": the actual
+// words, written on a page, fading and blurring exactly as your recall
+// does (opacity/blur ∝ e^(-t/S)). A ghost word is one you can no longer
+// read — because you can no longer recall it. Hovering a ghost sharpens
+// it back into focus: remembering, made visible.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, sampleVocab } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, hash } from "./chassis";
+
+type Kind = "strong" | "ok" | "fading" | "asleep";
+type Word = { i: number; arabizi: string; english: string; kind: Kind };
+
+const KIND_STYLE: Record<Kind, string> = {
+  strong: "text-gray-900 opacity-100",
+  ok: "text-gray-800 opacity-80 blur-[0.4px]",
+  fading: "text-gray-600 opacity-55 blur-[1px]",
+  asleep: "text-gray-500 opacity-25 blur-[2.4px]",
+};
+
+const KIND_LABEL: Record<Kind, string> = {
+  strong: "crisp — you know this one",
+  ok: "settled",
+  fading: "fading — the ink is going",
+  asleep: "almost gone — review to re-ink it",
+};
+
+function mix(n: number): number {
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  return (n ^ (n >>> 16)) >>> 0;
+}
+
+const SHOWN = 51;
+
+function buildWords(data: Scenario): Word[] {
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const started = total - data.counts.new;
+  const asleepShare = data.dueNow / Math.max(started, 1);
+  const vocab = sampleVocab(SHOWN, `${data.key}pgv`);
+  const words: Word[] = [];
+  for (let i = 0; i < SHOWN; i++) {
+    const h = mix(hash(`${data.key}pg${i}`));
+    const p = (h % 1000) / 1000;
+    let kind: Kind;
+    if (p < asleepShare) kind = "asleep";
+    else {
+      const s = (h >>> 10) % 100;
+      kind = s > 55 ? "strong" : s > 18 ? "ok" : "fading";
+    }
+    const [arabizi, english] = vocab[i % vocab.length];
+    words.push({ i, arabizi, english, kind });
+  }
+  return words;
+}
+
+export function PageVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [pin, setPin] = useState<Word | null>(null);
+  const [hover, setHover] = useState<Word | null>(null);
+  const sel = pin ?? hover;
+  const words = buildWords(data);
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const ghosts = words.filter((w) => w.kind === "asleep").length;
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${SHOWN} of ${total}`}>The page</Eyebrow>
+      </div>
+      <div
+        className="px-4 pt-2.5 pb-1 select-none"
+        aria-label={`Your vocabulary page: ${ghosts} of ${SHOWN} words have faded toward illegibility`}
+      >
+        <div className="flex flex-wrap items-baseline gap-x-[9px] gap-y-[3px]">
+          {words.map((w) => {
+            const selected = sel?.i === w.i;
+            return (
+              <button
+                key={w.i}
+                onMouseEnter={() => setHover(w)}
+                onClick={() => setPin(pin?.i === w.i ? null : w)}
+                aria-label={`${w.arabizi} — ${KIND_LABEL[w.kind]}`}
+                className={cn(
+                  "font-medium text-[13.5px] leading-6 rounded-sm transition-[filter,opacity,color] duration-300",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+                  selected ? "text-green-700 opacity-100 blur-0" : KIND_STYLE[w.kind]
+                )}
+              >
+                {w.arabizi}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="h-[52px] mx-3 mb-2.5 mt-1.5">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">{KIND_LABEL[sel.kind]}</div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span>
+              the ink fades as you forget —{" "}
+              <span className={cn("font-semibold", ghosts > SHOWN / 3 ? "text-amber-600" : "text-heading")}>
+                {ghosts} ghosts
+              </span>{" "}
+              on this page
+            </span>
+            <span className="ml-auto text-disabled shrink-0">hover to remember</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/StoryVariant.tsx
+++ b/app/design-lab/StoryVariant.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+// Variant T — "Three beats"
+// Pudding technique #4: scrollytelling — the same graphic re-read three
+// times with a changing sentence. Compressed into a panel-sized stepper:
+// one word-wall, three beats (what you have → what went quiet → the way
+// back), the wall restyling itself under each line.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, sampleKinds, sampleVocab, minutesFor, type SampleKind } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, DetailRow, type SpotWord } from "./chassis";
+
+const SHOWN = 24;
+
+export function StoryVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [beat, setBeat] = useState(0);
+  const [sel, setSel] = useState<SpotWord | null>(null);
+  const isBacklog = data.dueNow > 20;
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+
+  const kinds = sampleKinds(data, SHOWN, "story");
+  const vocab = sampleVocab(SHOWN, `${data.key}storyv`);
+  const words = kinds.map((kind, i) => ({ i, arabizi: vocab[i][0], english: vocab[i][1], kind }));
+  const rescue = words.filter((w) => w.kind === "asleep").slice(0, 3);
+
+  const beats = [
+    {
+      line: (
+        <>
+          You&apos;ve built a vocabulary of{" "}
+          <span className="font-mono font-semibold text-heading tabular-nums">{total}</span> words.
+        </>
+      ),
+      // beat 0: everything rendered at full strength — what you own
+      style: () => "text-gray-900 opacity-100",
+    },
+    {
+      line: isBacklog ? (
+        <>
+          <span className="font-mono font-semibold text-amber-600 tabular-nums">{data.dueNow}</span> of them
+          went quiet while you were away.
+        </>
+      ) : (
+        <>
+          Only <span className="font-mono font-semibold text-amber-600 tabular-nums">{data.dueNow}</span> are
+          wobbling right now.
+        </>
+      ),
+      // beat 2: honesty — the quiet ones fade, the rest hold
+      style: (kind: SampleKind) =>
+        kind === "asleep" ? "text-gray-400 opacity-25 blur-[1.6px]" : "text-gray-900 opacity-90",
+    },
+    {
+      line: (
+        <>
+          <span className="font-mono font-semibold text-green-700 tabular-nums">
+            {Math.min(10, Math.max(1, data.dueNow))}
+          </span>{" "}
+          words · {minutesFor(Math.min(10, Math.max(1, data.dueNow)))} min — and these three come back first.
+        </>
+      ),
+      // beat 3: hope — the rescue set relights, the rest recede
+      style: (kind: SampleKind, i: number) =>
+        rescue.some((r) => r.i === i)
+          ? "text-green-700 opacity-100 font-semibold"
+          : kind === "asleep"
+          ? "text-gray-400 opacity-20 blur-[1.6px]"
+          : "text-gray-500 opacity-45",
+    },
+  ];
+
+  const hero = (
+    <Card onMouseLeave={() => setSel(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`beat ${beat + 1} of 3`}>Your month, in three beats</Eyebrow>
+      </div>
+      <div className="px-4 pt-3 min-h-[54px]">
+        <p className="text-[13.5px] leading-relaxed text-body">{beats[beat].line}</p>
+      </div>
+      <div className="px-4 pt-2 pb-1 select-none">
+        <div className="flex flex-wrap items-baseline gap-x-[9px] gap-y-[3px]">
+          {words.map((w) => (
+            <button
+              key={w.i}
+              onMouseEnter={() => setSel({ arabizi: w.arabizi, english: w.english, note: w.kind === "asleep" ? "one of the quiet ones" : "holding on" })}
+              onClick={() =>
+                setSel({ arabizi: w.arabizi, english: w.english, note: w.kind === "asleep" ? "one of the quiet ones" : "holding on" })
+              }
+              className={cn(
+                "text-[13.5px] leading-6 font-medium rounded-sm transition-all duration-500",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+                sel?.arabizi === w.arabizi ? "text-green-700 opacity-100 blur-0" : beats[beat].style(w.kind, w.i)
+              )}
+            >
+              {w.arabizi}
+            </button>
+          ))}
+        </div>
+      </div>
+      {/* pager */}
+      <div className="px-4 pt-2.5 pb-1 flex items-center gap-2">
+        {[0, 1, 2].map((b) => (
+          <button
+            key={b}
+            onClick={() => setBeat(b)}
+            aria-label={`Beat ${b + 1}`}
+            aria-current={beat === b}
+            className={cn(
+              "h-6 rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+              beat === b ? "w-8 bg-green-600" : "w-6 bg-gray-200 hover:bg-gray-300"
+            )}
+            style={{ height: 6, marginTop: 8, marginBottom: 8 }}
+          />
+        ))}
+        <button
+          onClick={() => (beat < 2 ? setBeat(beat + 1) : onAction("Start a rescue session with my 10 weakest words"))}
+          className="ml-auto h-8 px-3 rounded-lg text-xs font-semibold text-green-700 hover:bg-green-50 active:bg-green-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+        >
+          {beat < 2 ? "next →" : "yalla →"}
+        </button>
+      </div>
+      <DetailRow
+        word={sel}
+        onAction={onAction}
+        hint={
+          <>
+            <span>same wall, three readings — tap the dots</span>
+            <span className="ml-auto text-disabled shrink-0">hover a word</span>
+          </>
+        }
+      />
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/SynapseVariant.tsx
+++ b/app/design-lab/SynapseVariant.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+// Variant K — "Synapses"
+// The other literal answer: see the brain itself. Each word is a neuron;
+// synapses connect neighbors. Strong memories glow green with soft halos,
+// fading ones cool to ember amber, forgotten ones go dark — and their
+// synapses dim with them. A backlog looks like a mind going quiet;
+// reviewing lights the network back up.
+
+import { useState } from "react";
+import { type Scenario, VOCAB_LOOKUP } from "./fixtures";
+import { Card, Eyebrow, MissionChassis, hash } from "./chassis";
+
+type Kind = "strong" | "ok" | "fading" | "asleep";
+type Node = { i: number; arabizi: string; english: string; kind: Kind; x: number; y: number };
+
+const NODE_FILL: Record<Kind, string> = {
+  strong: "#16a34a",
+  ok: "#4ade80",
+  fading: "#f59e0b",
+  asleep: "#d1d5db",
+};
+
+const KIND_LABEL: Record<Kind, string> = {
+  strong: "firing strong",
+  ok: "settled",
+  fading: "cooling — review soon",
+  asleep: "gone dark — needs a review",
+};
+
+function mix(n: number): number {
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  return (n ^ (n >>> 16)) >>> 0;
+}
+
+const r2 = (v: number) => Math.round(v * 100) / 100;
+const SHOWN = 42;
+// R2 low-discrepancy sequence constants — even, organic-feeling scatter.
+const A1 = 0.7548776662;
+const A2 = 0.5698402909;
+
+function buildNetwork(data: Scenario): { nodes: Node[]; edges: [Node, Node][] } {
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const started = total - data.counts.new;
+  const asleepShare = data.dueNow / Math.max(started, 1);
+  const nodes: Node[] = [];
+  for (let i = 0; i < SHOWN; i++) {
+    const h = mix(hash(`${data.key}nr${i}`));
+    const jx = ((h % 100) / 100 - 0.5) * 14;
+    const jy = (((h >>> 8) % 100) / 100 - 0.5) * 12;
+    const p = ((h >>> 16) % 1000) / 1000;
+    let kind: Kind;
+    if (p < asleepShare) kind = "asleep";
+    else {
+      const s = (h >>> 4) % 100;
+      kind = s > 55 ? "strong" : s > 18 ? "ok" : "fading";
+    }
+    const [arabizi, english] = VOCAB_LOOKUP[(h >>> 5) % VOCAB_LOOKUP.length];
+    nodes.push({
+      i,
+      arabizi,
+      english,
+      kind,
+      x: r2(20 + ((i * A1) % 1) * 248 + jx),
+      y: r2(20 + ((i * A2) % 1) * 158 + jy),
+    });
+  }
+  // Synapses: each neuron reaches for its two nearest neighbors.
+  const edges: [Node, Node][] = [];
+  const seen = new Set<string>();
+  for (const n of nodes) {
+    const nearest = nodes
+      .filter((m) => m.i !== n.i)
+      .sort((a, b) => (a.x - n.x) ** 2 + (a.y - n.y) ** 2 - ((b.x - n.x) ** 2 + (b.y - n.y) ** 2))
+      .slice(0, 2);
+    for (const m of nearest) {
+      const key = n.i < m.i ? `${n.i}-${m.i}` : `${m.i}-${n.i}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        edges.push([n, m]);
+      }
+    }
+  }
+  return { nodes, edges };
+}
+
+export function SynapseVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [pin, setPin] = useState<Node | null>(null);
+  const [hover, setHover] = useState<Node | null>(null);
+  const sel = pin ?? hover;
+  const { nodes, edges } = buildNetwork(data);
+  const dark = nodes.filter((n) => n.kind === "asleep").length;
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right={`${dark}/${SHOWN} dark`}>Synapses</Eyebrow>
+      </div>
+      <svg
+        viewBox="0 0 288 198"
+        className="w-full block"
+        role="img"
+        aria-label={`Your memory network: ${dark} of ${SHOWN} sampled words have gone dark`}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            setPin(null);
+            setHover(null);
+          }
+        }}
+      >
+        {/* synapses first, under the neurons */}
+        {edges.map(([a, b]) => {
+          const alive = a.kind !== "asleep" && b.kind !== "asleep";
+          const mx = (a.x + b.x) / 2 + (a.y - b.y) * 0.18;
+          const my = (a.y + b.y) / 2 + (b.x - a.x) * 0.18;
+          const involved = sel !== null && (sel.i === a.i || sel.i === b.i);
+          return (
+            <path
+              key={`${a.i}-${b.i}`}
+              d={`M ${a.x} ${a.y} Q ${r2(mx)} ${r2(my)} ${b.x} ${b.y}`}
+              fill="none"
+              stroke={alive ? "#16a34a" : "#9ca3af"}
+              strokeWidth={involved ? 1.3 : 0.8}
+              opacity={sel !== null && !involved ? 0.06 : alive ? 0.3 : 0.12}
+              style={{ transition: "opacity 200ms ease" }}
+            />
+          );
+        })}
+        {/* halos on live neurons */}
+        {nodes
+          .filter((n) => n.kind === "strong")
+          .map((n) => (
+            <circle key={`h${n.i}`} cx={n.x} cy={n.y} r={7.5} fill="#22c55e" className="lab-glow" />
+          ))}
+        {/* neurons */}
+        {nodes.map((n) => {
+          const selected = sel?.i === n.i;
+          const dimmed = sel !== null && !selected;
+          return (
+            <circle
+              key={n.i}
+              cx={n.x}
+              cy={n.y}
+              r={selected ? 5 : n.kind === "strong" ? 3.4 : n.kind === "asleep" ? 2.6 : 3}
+              fill={NODE_FILL[n.kind]}
+              stroke={selected ? "#111827" : "none"}
+              strokeWidth={selected ? 1.5 : 0}
+              style={{ opacity: dimmed ? 0.25 : 1, transition: "opacity 200ms ease" }}
+              className="cursor-pointer"
+              onMouseEnter={() => setHover(n)}
+              onClick={() => setPin(pin?.i === n.i ? null : n)}
+            />
+          );
+        })}
+      </svg>
+      <div className="h-[52px] mx-3 mb-2.5 mt-0.5">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">{KIND_LABEL[sel.kind]}</div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-green-600 inline-block" /> firing
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-amber-500 inline-block" /> cooling
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-2 h-2 rounded-full bg-gray-300 inline-block" /> dark
+            </span>
+            <span className="ml-auto text-disabled">hover or tap</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/WordDriftVariant.tsx
+++ b/app/design-lab/WordDriftVariant.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+// Variant N — "Word drift"
+// Drift's axis, but the words themselves are the marks: your vocabulary
+// strewn across the memory axis, crisp on the right, dissolving as it
+// drifts left past the due line. Position = the same e^(-t/S) the SRS
+// schedules with; type replaces dots entirely.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Scenario, type LabWord, retention, sampleKinds, sampleVocab, seeded, type SampleKind } from "./fixtures";
+import { Card, Eyebrow, MissionChassis } from "./chassis";
+
+type Item = {
+  key: string;
+  arabizi: string;
+  english: string;
+  kind: SampleKind;
+  /** 0..1 along the memory axis */
+  t: number;
+  real?: LabWord;
+};
+
+const KIND_STYLE: Record<SampleKind, string> = {
+  strong: "text-gray-900 opacity-100",
+  ok: "text-gray-700 opacity-85 blur-[0.3px]",
+  fading: "text-amber-700/80 opacity-65 blur-[0.9px]",
+  asleep: "text-gray-500 opacity-25 blur-[2px]",
+};
+
+const KIND_LABEL: Record<SampleKind, string> = {
+  strong: "solid — far from the edge",
+  ok: "settled",
+  fading: "drifting — review soon",
+  asleep: "past the due line",
+};
+
+const DUE_T = 0.3;
+
+function axisT(word: LabWord): { t: number; kind: SampleKind } {
+  if (word.dueInDays < -0.5) {
+    // deeper overdue drifts further left
+    const t = Math.max(0.02, DUE_T - 0.04 - Math.min(-word.dueInDays, 15) * 0.016);
+    return { t, kind: "asleep" };
+  }
+  const r = retention(word) ?? 0.5;
+  return { t: DUE_T + 0.06 + r * (0.94 - DUE_T - 0.06), kind: r > 0.75 ? "strong" : r > 0.45 ? "ok" : "fading" };
+}
+
+const MAX_GHOSTS = 8;
+
+function buildItems(data: Scenario): { items: Item[]; hiddenAsleep: number } {
+  // Real fixture words carry the interaction; synthetic ones fill the field.
+  const real: Item[] = data.words
+    .filter((w) => w.reviewCount > 0 || w.dueInDays < -0.5)
+    .map((w) => {
+      const { t, kind } = axisT(w);
+      return { key: w.id, arabizi: w.arabizi, english: w.english, kind, t, real: w };
+    });
+  // Pad only the awake side — more ghosts would just pile onto the column.
+  const padKinds = sampleKinds(data, 10, "wd").filter((k) => k !== "asleep");
+  const padVocab = sampleVocab(padKinds.length, `${data.key}wdv`);
+  const pad: Item[] = padKinds.map((kind, i) => {
+    const h = seeded(`${data.key}wdt${i}`);
+    const u = (h % 1000) / 1000;
+    const t = DUE_T + 0.08 + u * (0.94 - DUE_T - 0.08);
+    const [arabizi, english] = padVocab[i];
+    return { key: `p${i}`, arabizi, english, kind, t };
+  });
+  // Show only the most recently slipped ghosts; the rest become a count.
+  const all = [...real, ...pad];
+  const ghosts = all.filter((it) => it.kind === "asleep").sort((a, b) => b.t - a.t);
+  const shownGhosts = new Set(ghosts.slice(0, MAX_GHOSTS).map((g) => g.key));
+  const items = all.filter((it) => it.kind !== "asleep" || shownGhosts.has(it.key));
+  return { items, hiddenAsleep: Math.max(0, data.dueNow - Math.min(ghosts.length, MAX_GHOSTS)) };
+}
+
+/** Greedy lane packing so words never overlap: sort by x, first free lane. */
+function layout(items: Item[], width: number): (Item & { x: number; lane: number })[] {
+  const sorted = [...items].sort((a, b) => a.t - b.t);
+  const laneEnds: number[] = [];
+  return sorted.map((it) => {
+    const w = it.arabizi.length * 7.2 + 6;
+    let x = 8 + it.t * (width - 16) - w / 2;
+    x = Math.max(4, Math.min(width - w - 4, x));
+    let lane = laneEnds.findIndex((end) => end <= x);
+    if (lane === -1) {
+      lane = laneEnds.length;
+      laneEnds.push(0);
+    }
+    laneEnds[lane] = x + w;
+    return { ...it, x, lane };
+  });
+}
+
+export function WordDriftVariant({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const [pin, setPin] = useState<Item | null>(null);
+  const [hover, setHover] = useState<Item | null>(null);
+  const sel = pin ?? hover;
+
+  const WIDTH = 340;
+  const { items, hiddenAsleep } = buildItems(data);
+  const placed = layout(items, WIDTH);
+  const lanes = Math.max(...placed.map((p) => p.lane)) + 1;
+  const LANE_H = 24;
+  const height = lanes * LANE_H + 12;
+  const asleepCount = data.dueNow;
+
+  const hero = (
+    <Card onMouseLeave={() => setHover(null)}>
+      <div className="px-4 pt-3">
+        <Eyebrow right="left = fading away">Word drift</Eyebrow>
+      </div>
+      <div className="relative mx-2 mt-2 select-none" style={{ height }}>
+        {/* due line */}
+        <div
+          className="absolute top-0 bottom-0 border-l border-dashed"
+          style={{ left: 8 + DUE_T * (WIDTH - 16), borderColor: asleepCount > 0 ? "#fca5a5" : "#e5e7eb" }}
+          aria-hidden="true"
+        />
+        {hiddenAsleep > 0 && (
+          <button
+            onClick={() => onAction(`Start a rescue session with my 10 weakest words`)}
+            style={{ left: 8, bottom: 2 }}
+            className="absolute font-mono text-[9.5px] text-amber-600/80 border border-dashed border-amber-300 rounded px-1.5 py-0.5 hover:bg-amber-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 transition-colors"
+          >
+            +{hiddenAsleep} more asleep
+          </button>
+        )}
+        {placed.map((it) => {
+          const selected = sel?.key === it.key;
+          const dimmed = sel !== null && !selected;
+          return (
+            <button
+              key={it.key}
+              onMouseEnter={() => setHover(it)}
+              onClick={() => setPin(pin?.key === it.key ? null : it)}
+              aria-label={`${it.arabizi} — ${KIND_LABEL[it.kind]}`}
+              style={{ left: it.x, top: 6 + it.lane * LANE_H }}
+              className={cn(
+                "absolute text-[13px] font-medium leading-5 px-0.5 rounded-sm whitespace-nowrap",
+                "transition-[filter,opacity,color] duration-300",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600",
+                selected ? "text-green-700 opacity-100 blur-0 z-10" : KIND_STYLE[it.kind],
+                dimmed && "opacity-15"
+              )}
+            >
+              {it.arabizi}
+            </button>
+          );
+        })}
+      </div>
+      {/* axis labels */}
+      <div className="relative mx-2 h-5 text-[9px] font-mono" aria-hidden="true">
+        <span className={cn("absolute", asleepCount > 20 ? "text-amber-600 font-semibold" : "text-disabled")} style={{ left: 12 }}>
+          asleep {asleepCount}
+        </span>
+        <span className="absolute text-disabled" style={{ left: 8 + DUE_T * (WIDTH - 16) - 14 }}>
+          due
+        </span>
+        <span className="absolute right-3 text-disabled">solid</span>
+      </div>
+      <div className="h-[52px] mx-3 mb-2.5 mt-0.5">
+        {sel ? (
+          <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="truncate">
+                <span className="text-sm font-semibold text-heading">{sel.arabizi}</span>
+                <span className="ml-2 text-xs text-subtle">{sel.english}</span>
+              </div>
+              <div className="font-mono text-[10px] text-disabled mt-0.5">{KIND_LABEL[sel.kind]}</div>
+            </div>
+            <button
+              onClick={() => onAction(`Quiz me on "${sel.arabizi}"`)}
+              className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+            >
+              Quiz me
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">
+            <span>
+              reviews pull words <span className="text-heading font-semibold">→ right</span>; time drags them
+              toward the <span className={cn("font-semibold", asleepCount > 20 ? "text-amber-600" : "text-heading")}>due line</span>
+            </span>
+            <span className="ml-auto text-disabled shrink-0">hover or tap</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+
+  return <MissionChassis data={data} onAction={onAction} hero={hero} />;
+}

--- a/app/design-lab/chassis.tsx
+++ b/app/design-lab/chassis.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+// Shared "mission control" chassis. Every variant keeps this structure —
+// hero visual, one next action sized in minutes, human stats, five weakest
+// words — and swaps only the hero. So the comparison is purely about the
+// visual layer.
+
+import { cn } from "@/lib/utils";
+import { type Scenario, type LabWord, retention, weakestFirst, minutesFor } from "./fixtures";
+
+export function Card({
+  className,
+  children,
+  onMouseLeave,
+}: {
+  className?: string;
+  children: React.ReactNode;
+  onMouseLeave?: () => void;
+}) {
+  return (
+    <section
+      className={cn("rounded-xl bg-white border border-gray-200/80 shadow-[0_1px_2px_rgba(16,24,40,0.05)]", className)}
+      onMouseLeave={onMouseLeave}
+    >
+      {children}
+    </section>
+  );
+}
+
+export function Eyebrow({ children, right }: { children: React.ReactNode; right?: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between">
+      <span className="text-[10px] font-mono uppercase tracking-[0.14em] text-subtle">{children}</span>
+      {right && <span className="text-[10px] font-mono text-disabled">{right}</span>}
+    </div>
+  );
+}
+
+function NextAction({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const isBacklog = data.dueNow > 20;
+  const bite = Math.min(10, Math.max(1, data.dueNow));
+  const daysToClear = Math.max(1, Math.ceil(data.dueNow / 25));
+
+  return (
+    <Card className="px-4 py-3.5">
+      <Eyebrow>{isBacklog ? "Recovery plan" : "Next up"}</Eyebrow>
+      {isBacklog ? (
+        <>
+          <p className="mt-1.5 text-[13px] leading-snug text-body">
+            <span className="font-semibold text-heading tabular-nums">{data.dueNow} words</span> went quiet
+            while you were away. 25 a day wakes them all in{" "}
+            <span className="font-semibold text-heading tabular-nums">{daysToClear} days</span>.
+          </p>
+          <button
+            onClick={() => onAction(`Start a rescue session with my ${bite} weakest words`)}
+            className="mt-3 w-full h-11 rounded-lg bg-green-600 text-white text-sm font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2 transition-colors"
+          >
+            Wake the {bite} weakest · {minutesFor(bite)} min
+          </button>
+          <button
+            onClick={() => onAction("Start a full review session")}
+            className="mt-2 w-full h-10 rounded-lg text-[13px] font-medium text-subtle hover:bg-gray-50 active:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+          >
+            I have time — full session ({minutesFor(25)} min)
+          </button>
+        </>
+      ) : data.dueNow > 0 ? (
+        <>
+          <p className="mt-1.5 text-[13px] leading-snug text-body">
+            <span className="font-semibold text-heading tabular-nums">{data.dueNow} words due</span> — quick
+            one before they fade.
+          </p>
+          <button
+            onClick={() => onAction(`Review my ${data.dueNow} due words`)}
+            className="mt-3 w-full h-11 rounded-lg bg-green-600 text-white text-sm font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2 transition-colors"
+          >
+            Clear them · {minutesFor(data.dueNow)} min
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="mt-1.5 text-[13px] leading-snug text-body">All caught up. Get ahead of tomorrow:</p>
+          <button
+            onClick={() => onAction("Teach me 3 new words")}
+            className="mt-3 w-full h-11 rounded-lg bg-green-600 text-white text-sm font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 focus-visible:ring-offset-2 transition-colors"
+          >
+            Learn 3 new words · 2 min
+          </button>
+        </>
+      )}
+    </Card>
+  );
+}
+
+function Stats({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const max = Math.max(...data.reviewsByDay, 1);
+  return (
+    <Card className="px-4 py-3 grid grid-cols-3">
+      <button
+        onClick={() => onAction("Tell me about my streak")}
+        className="text-left rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600"
+      >
+        <div className={cn("font-mono text-[17px] tabular-nums leading-6", data.streak > 0 ? "text-heading" : "text-disabled")}>
+          {data.streak}
+          {data.streak > 0 && <span className="text-[13px]"> 🔥</span>}
+        </div>
+        <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-disabled mt-1">Streak</div>
+      </button>
+      <button
+        onClick={() => onAction("How am I doing on today's goal?")}
+        className="text-left rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600"
+      >
+        <div className="font-mono text-[17px] tabular-nums leading-6 text-heading">
+          {data.reviewedToday}
+          <span className="text-disabled text-[13px]">/{data.dailyGoal}</span>
+        </div>
+        <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-disabled mt-1">Today</div>
+      </button>
+      <button
+        onClick={() => onAction("Show my progress this week")}
+        className="text-left rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600"
+        aria-label={`Reviews this week: ${data.reviewsByDay.join(", ")}`}
+      >
+        <div className="flex items-end gap-[3px] h-6" aria-hidden="true">
+          {data.reviewsByDay.map((n, i) => (
+            <span
+              key={i}
+              style={{ height: Math.max(3, Math.round((n / max) * 22)) }}
+              className={cn("w-[6px] rounded-[1.5px]", n === 0 ? "bg-gray-200" : "bg-green-500")}
+            />
+          ))}
+        </div>
+        <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-disabled mt-1">Week</div>
+      </button>
+    </Card>
+  );
+}
+
+function Weakest({ data, onAction }: { data: Scenario; onAction: (a: string) => void }) {
+  const rows = weakestFirst(data.words).slice(0, 5);
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  return (
+    <Card>
+      <div className="px-4 pt-3 pb-2 border-b border-gray-100">
+        <Eyebrow right="tap to quiz">Slipping first</Eyebrow>
+      </div>
+      <div className="px-2.5 py-1">
+        {rows.map((w) => (
+          <Row key={w.id} word={w} onAction={onAction} />
+        ))}
+      </div>
+      <button
+        onClick={() => onAction("Show me all my words")}
+        className="w-full h-10 text-xs font-medium text-subtle border-t border-gray-100 hover:bg-gray-50 active:bg-gray-100 rounded-b-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+      >
+        See all {total} words
+      </button>
+    </Card>
+  );
+}
+
+function Row({ word, onAction }: { word: LabWord; onAction: (a: string) => void }) {
+  const r = retention(word);
+  const overdue = word.dueInDays < -0.5;
+  return (
+    <button
+      onClick={() => onAction(`Quiz me on "${word.arabizi}"`)}
+      className="w-full flex items-baseline gap-3 h-11 px-1.5 text-left rounded-md hover:bg-gray-50 active:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+    >
+      <span className="text-sm font-medium text-heading truncate w-[84px] shrink-0">{word.arabizi}</span>
+      <span className="flex-1 min-w-0 truncate text-xs text-subtle">{word.english}</span>
+      {r === null ? (
+        <span className="font-mono text-[10px] text-disabled">new</span>
+      ) : overdue ? (
+        <span className="font-mono text-[11px] text-amber-600 tabular-nums shrink-0">
+          asleep {Math.round(-word.dueInDays)}d
+        </span>
+      ) : (
+        <span
+          className={cn(
+            "font-mono text-[11px] tabular-nums shrink-0",
+            r > 0.75 ? "text-green-600" : r > 0.45 ? "text-amber-500" : "text-red-500"
+          )}
+        >
+          {Math.round(r * 100)}%
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function MissionChassis({
+  data,
+  onAction,
+  hero,
+  hideWeakest,
+}: {
+  data: Scenario;
+  onAction: (a: string) => void;
+  hero: React.ReactNode;
+  /** for heroes that already ARE the word list (e.g. the ledger) */
+  hideWeakest?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2.5 p-3 bg-gray-50 min-h-full">
+      {hero}
+      <NextAction data={data} onAction={onAction} />
+      <Stats data={data} onAction={onAction} />
+      {!hideWeakest && <Weakest data={data} onAction={onAction} />}
+    </div>
+  );
+}
+
+export function hash(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+export interface SpotWord {
+  arabizi: string;
+  english: string;
+  note: string;
+}
+
+/** Fixed-height footer row: legend/hint by default, word card when selected. */
+export function DetailRow({
+  word,
+  hint,
+  onAction,
+}: {
+  word: SpotWord | null;
+  hint: React.ReactNode;
+  onAction: (a: string) => void;
+}) {
+  return (
+    <div className="h-[52px] mx-3 mb-2.5 mt-1.5">
+      {word ? (
+        <div className="h-full flex items-center gap-3 rounded-lg bg-gray-50 px-3">
+          <div className="flex-1 min-w-0 leading-tight">
+            <div className="truncate">
+              <span className="text-sm font-semibold text-heading">{word.arabizi}</span>
+              <span className="ml-2 text-xs text-subtle">{word.english}</span>
+            </div>
+            <div className="font-mono text-[10px] text-disabled mt-0.5">{word.note}</div>
+          </div>
+          <button
+            onClick={() => onAction(`Quiz me on "${word.arabizi}"`)}
+            className="shrink-0 h-9 px-3.5 rounded-lg bg-green-600 text-white text-xs font-semibold hover:bg-green-700 active:bg-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600 transition-colors"
+          >
+            Quiz me
+          </button>
+        </div>
+      ) : (
+        <div className="h-full flex items-center gap-3.5 px-1.5 text-[10px] font-mono text-subtle">{hint}</div>
+      )}
+    </div>
+  );
+}

--- a/app/design-lab/fixtures.ts
+++ b/app/design-lab/fixtures.ts
@@ -1,0 +1,274 @@
+// Shared fixture data for the design lab. Every variant renders from the same
+// two scenarios so the comparison is fair:
+//  - "backlog": mirrors the real screenshot state (126 due, retention floored)
+//  - "healthy": a user who reviewed this morning
+// Time is modeled as relative days (lastReviewedDaysAgo / dueInDays) so the
+// lab is deterministic and never touches the real clock.
+
+export type Status = "new" | "learning" | "learned";
+
+export interface LabWord {
+  id: string;
+  arabizi: string;
+  english: string;
+  status: Status;
+  /** current SRS interval in days */
+  interval: number;
+  reviewCount: number;
+  /** days since last review (drives retention decay) */
+  lastReviewedDaysAgo: number;
+  /** days until next review; negative = overdue by that many days */
+  dueInDays: number;
+}
+
+export interface Scenario {
+  key: "backlog" | "healthy";
+  label: string;
+  counts: { new: number; learning: number; learned: number };
+  dueNow: number;
+  streak: number;
+  bestStreak: number;
+  reviewedToday: number;
+  dailyGoal: number;
+  /** reviews per day, oldest first, last entry = today */
+  reviewsByDay: number[];
+  /** words newly coming due per day for the next 7 days (excludes backlog) */
+  incomingByDay: number[];
+  words: LabWord[];
+}
+
+// Ebbinghaus estimate, same formula as production: R = e^(-t/S).
+export function retention(w: LabWord): number | null {
+  if (w.reviewCount === 0) return null;
+  const stability = Math.max(w.interval, 1 / 24);
+  return Math.exp(-w.lastReviewedDaysAgo / stability);
+}
+
+/** Words sorted weakest-signal first; unreviewed words go last. */
+export function weakestFirst(words: LabWord[]): LabWord[] {
+  return [...words].sort((a, b) => {
+    const ra = retention(a);
+    const rb = retention(b);
+    if (ra === null && rb === null) return 0;
+    if (ra === null) return 1;
+    if (rb === null) return -1;
+    return ra - rb;
+  });
+}
+
+export function minutesFor(count: number): number {
+  return Math.max(1, Math.round(count * 0.4));
+}
+
+export const VOCAB_LOOKUP: [string, string][] = [
+  ["3am", "present continuous marker"],
+  ["zayyan", "decorate"],
+  ["jbiin", "forehead"],
+  ["daye3", "lost"],
+  ["habis", "prison"],
+  ["asfar", "yellow"],
+  ["mughtarib", "expatriate"],
+  ["teerikh", "date / history"],
+  ["me2leye", "fried food"],
+  ["shu", "what"],
+  ["kifak", "how are you"],
+  ["yalla", "let's go"],
+  ["bukra", "tomorrow"],
+  ["shway", "a little"],
+  ["ktir", "a lot"],
+  ["sohtayn", "bon appétit"],
+  ["dala3", "pampering"],
+  ["za3lan", "upset"],
+  ["mnee7", "good"],
+  ["ta3a", "come here"],
+  ["ba3dein", "later"],
+  ["hallak", "now"],
+  ["mbere7", "yesterday"],
+  ["jeb", "he brought"],
+  ["khalas", "enough / done"],
+  ["akid", "for sure"],
+  ["ma3le", "never mind"],
+  ["sahra", "evening gathering"],
+  ["bayt", "house"],
+  ["shams", "sun"],
+  ["amar", "moon"],
+  ["ba7r", "sea"],
+  ["jabal", "mountain"],
+  ["khebez", "bread"],
+  ["zeitoun", "olives"],
+  ["ahwe", "coffee"],
+  ["mayy", "water"],
+  ["sob7iyye", "morning coffee chat"],
+  ["layl", "night"],
+  ["sa3a", "hour / watch"],
+  ["shughl", "work"],
+  ["teta", "grandma"],
+  ["jiddo", "grandpa"],
+  ["kbir", "big"],
+  ["zghir", "small"],
+  ["jdid", "new"],
+  ["helou", "sweet / lovely"],
+  ["skhen", "hot"],
+  ["berid", "cold"],
+  ["3anjad", "really"],
+  ["ya3ne", "I mean…"],
+  ["bass", "but / only"],
+  ["kamen", "also"],
+  ["hayda", "this"],
+  ["hon", "here"],
+  ["badde", "I want"],
+  ["fiyye", "I can"],
+  ["daghre", "straight ahead"],
+  ["3a mahlak", "slow down"],
+];
+
+function word(
+  i: number,
+  status: Status,
+  interval: number,
+  reviewCount: number,
+  lastReviewedDaysAgo: number,
+  dueInDays: number
+): LabWord {
+  const [arabizi, english] = VOCAB_LOOKUP[i % VOCAB_LOOKUP.length];
+  return { id: `w${i}`, arabizi, english, status, interval, reviewCount, lastReviewedDaysAgo, dueInDays };
+}
+
+// ---------------------------------------------------------------------------
+// Backlog: two weeks away. Most words overdue with a *spread* of decay so
+// ordering stays meaningful; a few brand-new words wait at the bottom.
+// ---------------------------------------------------------------------------
+const backlogWords: LabWord[] = [
+  word(0, "learning", 1, 3, 16, -15),
+  word(1, "learning", 1, 2, 15, -14),
+  word(2, "learning", 2, 4, 16, -14),
+  word(3, "learning", 2, 3, 14, -12),
+  word(4, "learning", 3, 5, 15, -12),
+  word(5, "learning", 3, 4, 13, -10),
+  word(6, "learning", 4, 6, 14, -10),
+  word(7, "learned", 6, 7, 15, -9),
+  word(8, "learned", 6, 8, 13, -7),
+  word(9, "learned", 8, 9, 14, -6),
+  word(10, "learned", 8, 7, 12, -4),
+  word(11, "learned", 10, 10, 13, -3),
+  word(12, "learned", 12, 11, 14, -2),
+  word(13, "learned", 14, 12, 15, -1),
+  word(14, "learned", 21, 13, 16, 5),
+  word(15, "learned", 30, 14, 15, 15),
+  word(16, "learned", 45, 16, 14, 31),
+  word(17, "learned", 60, 18, 13, 47),
+  word(18, "new", 0, 0, 0, 0),
+  word(19, "new", 0, 0, 0, 0),
+  word(20, "new", 0, 0, 0, 0),
+];
+
+// ---------------------------------------------------------------------------
+// Healthy: reviewed this morning, small queue coming due tonight.
+// ---------------------------------------------------------------------------
+const healthyWords: LabWord[] = [
+  word(0, "learning", 1, 3, 1.1, -0.1),
+  word(1, "learning", 1, 2, 0.9, 0.1),
+  word(2, "learning", 2, 4, 1.6, 0.4),
+  word(3, "learning", 3, 5, 1.8, 1.2),
+  word(4, "learning", 4, 6, 2.0, 2),
+  word(5, "learned", 6, 7, 2.5, 3.5),
+  word(6, "learned", 8, 8, 3, 5),
+  word(7, "learned", 10, 9, 3, 7),
+  word(8, "learned", 12, 10, 4, 8),
+  word(9, "learned", 14, 11, 4, 10),
+  word(10, "learned", 21, 12, 5, 16),
+  word(11, "learned", 30, 13, 6, 24),
+  word(12, "learned", 45, 15, 7, 38),
+  word(13, "learned", 60, 17, 8, 52),
+  word(14, "new", 0, 0, 0, 0),
+  word(15, "new", 0, 0, 0, 0),
+];
+
+export const SCENARIOS: Record<"backlog" | "healthy", Scenario> = {
+  backlog: {
+    key: "backlog",
+    label: "Backlog (the screenshot: 2 weeks away, 126 due)",
+    counts: { new: 35, learning: 37, learned: 128 },
+    dueNow: 126,
+    streak: 0,
+    bestStreak: 21,
+    reviewedToday: 0,
+    dailyGoal: 10,
+    reviewsByDay: [24, 18, 0, 0, 0, 0, 0],
+    incomingByDay: [2, 1, 3, 0, 2, 4, 1],
+    words: backlogWords,
+  },
+  healthy: {
+    key: "healthy",
+    label: "Healthy (reviewed this morning)",
+    counts: { new: 35, learning: 37, learned: 128 },
+    dueNow: 3,
+    streak: 12,
+    bestStreak: 21,
+    reviewedToday: 7,
+    dailyGoal: 10,
+    reviewsByDay: [12, 15, 9, 22, 11, 14, 7],
+    incomingByDay: [3, 5, 2, 7, 4, 9, 3],
+    words: healthyWords,
+  },
+};
+
+// Milestones tied to real-life ability, not algorithm internals.
+export const MILESTONES = [
+  { at: 25, title: "Taxi talk", detail: "Directions, greetings, thank-yous" },
+  { at: 75, title: "Souk bargaining", detail: "Numbers, colors, 'ktir ghale!'" },
+  { at: 150, title: "Kitchen with teta", detail: "Food words and pampering" },
+  { at: 250, title: "Sahra survivor", detail: "Hold your own all evening" },
+  { at: 400, title: "Mughtarib no more", detail: "Dream in arabizi" },
+];
+
+/** total "known" words for milestone math: learned + half-credit for learning */
+export function knownWords(s: Scenario): number {
+  return s.counts.learned + Math.round(s.counts.learning / 2);
+}
+
+// ---------------------------------------------------------------------------
+// Shared sampling helpers for the design lab visuals
+// ---------------------------------------------------------------------------
+
+function hashStr(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+/** Avalanche mix — plain string hashes give consecutive values for
+ * consecutive suffixes, which correlates anything derived from them. */
+export function mix(n: number): number {
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  n = Math.imul(n ^ (n >>> 16), 0x45d9f3b);
+  return (n ^ (n >>> 16)) >>> 0;
+}
+
+export function seeded(seed: string): number {
+  return mix(hashStr(seed));
+}
+
+export type SampleKind = "strong" | "ok" | "fading" | "asleep";
+
+/** Deterministic sample of word states matching the scenario's proportions. */
+export function sampleKinds(data: Scenario, count: number, seed: string): SampleKind[] {
+  const total = data.counts.new + data.counts.learning + data.counts.learned;
+  const started = total - data.counts.new;
+  const asleepShare = data.dueNow / Math.max(started, 1);
+  return Array.from({ length: count }, (_, i) => {
+    const h = seeded(`${data.key}${seed}${i}`);
+    const p = (h % 1000) / 1000;
+    if (p < asleepShare) return "asleep";
+    const s = (h >>> 10) % 100;
+    return s > 55 ? "strong" : s > 18 ? "ok" : "fading";
+  });
+}
+
+/** Distinct vocab entries (no repeats): a seeded shuffle of the whole pool. */
+export function sampleVocab(count: number, seed: string): [string, string][] {
+  return VOCAB_LOOKUP.map((entry, i) => ({ entry, k: seeded(`${seed}${i}`) }))
+    .sort((a, b) => a.k - b.k)
+    .slice(0, Math.min(count, VOCAB_LOOKUP.length))
+    .map(({ entry }) => entry);
+}

--- a/app/design-lab/page.tsx
+++ b/app/design-lab/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+// Design lab for the V2 progress panel redesign — round 3.
+// Two finalists (Memory field, Orbit) on the shared mission-control
+// chassis, with motion and focus states. Temporary; deleted when done.
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { SCENARIOS, type Scenario } from "./fixtures";
+import { FeedbackOverlay } from "./FeedbackOverlay";
+import { FoldVariant } from "./FoldVariant";
+
+const VARIANTS: {
+  key: string;
+  name: string;
+  axis: string;
+  why: string;
+  Component: React.ComponentType<{ data: Scenario; onAction: (a: string) => void }>;
+}[] = [
+  {
+    key: "P",
+    name: "The fold — final candidate",
+    axis: "Words in memory order, hover expands in place",
+    why: "Your words strongest-first, fading by weight → opacity → blur, the amber fold where the asleep ones begin. Hovering a word scales it up in place — pure transform, so lines never re-wrap and nothing shifts. Tap pins it; the card offers the quiz.",
+    Component: FoldVariant,
+  },
+];
+
+// Lab-only keyframes. lab-settle: staggered dot entrance. lab-orbit: slow
+// elliptical drift (rotation inside the squashed plane). lab-zone: soft
+// pulse on the due zone. All disabled under prefers-reduced-motion.
+const LAB_CSS = `
+@keyframes lab-settle { from { opacity: 0 } to { opacity: 1 } }
+.lab-settle { animation: lab-settle 500ms ease-out backwards; }
+@keyframes lab-orbit { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }
+.lab-orbit { animation: lab-orbit 160s linear infinite; transform-origin: 0 0; }
+@keyframes lab-zone { 0%, 100% { fill-opacity: 0.55 } 50% { fill-opacity: 1 } }
+.lab-zone { animation: lab-zone 4.5s ease-in-out infinite; }
+@keyframes lab-glow { 0%, 100% { opacity: 0.1 } 50% { opacity: 0.26 } }
+.lab-glow { animation: lab-glow 5s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .lab-settle, .lab-orbit, .lab-zone, .lab-glow { animation: none !important; }
+}
+`;
+
+export default function DesignLabPage() {
+  const [scenarioKey, setScenarioKey] = useState<"backlog" | "healthy">("backlog");
+  const [actions, setActions] = useState<string[]>([]);
+  const scenario = SCENARIOS[scenarioKey];
+
+  // The app's offline service worker caches /_next assets on localhost and
+  // has repeatedly served stale CSS/JS for this page. Evict it here so the
+  // lab always renders current code.
+  useEffect(() => {
+    navigator.serviceWorker?.getRegistrations?.().then((regs) => regs.forEach((r) => r.unregister()));
+    if ("caches" in window) {
+      caches.keys().then((keys) =>
+        keys.forEach((k) => {
+          if (k.startsWith("arabic-flashcards-")) caches.delete(k);
+        })
+      );
+    }
+  }, []);
+
+  const onAction = (a: string) => setActions((prev) => [a, ...prev].slice(0, 3));
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <style>{LAB_CSS}</style>
+      <header className="sticky top-0 z-50 bg-white/90 backdrop-blur border-b border-gray-200 px-5 py-3">
+        <div className="max-w-[1000px] mx-auto flex flex-wrap items-center gap-x-6 gap-y-2">
+          <div>
+            <h1 className="text-base font-semibold text-gray-900">Design lab — ProgressPanel: the fold, final</h1>
+            <p className="text-xs text-gray-500">
+              The pick. Hover words to expand-in-place (no re-wrapping), flip the toggle for both states.
+              Confirm and I&apos;ll tear the lab down and build it into the real panel.
+            </p>
+          </div>
+          <div className="flex items-center gap-1 rounded-lg bg-gray-100 p-1 ml-auto" role="tablist" aria-label="Data scenario">
+            {(Object.keys(SCENARIOS) as ("backlog" | "healthy")[]).map((k) => (
+              <button
+                key={k}
+                role="tab"
+                aria-selected={scenarioKey === k}
+                onClick={() => setScenarioKey(k)}
+                className={cn(
+                  "px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+                  scenarioKey === k ? "bg-white shadow-sm text-gray-900" : "text-gray-500 hover:text-gray-700"
+                )}
+              >
+                {k === "backlog" ? "😵 Backlog (126 due)" : "😌 Healthy"}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-[1400px] mx-auto px-5 py-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 items-start justify-items-center">
+          {VARIANTS.map(({ key, name, axis, why, Component }) => (
+            <section key={key} data-variant={key} className="flex flex-col w-full max-w-[420px]">
+              <div className="mb-2.5 px-1">
+                <div className="flex items-baseline gap-2">
+                  <span className="w-6 h-6 rounded-full bg-gray-900 text-white text-xs font-bold flex items-center justify-center shrink-0">
+                    {key}
+                  </span>
+                  <h2 className="text-sm font-semibold text-gray-900">{name}</h2>
+                  <span className="text-[11px] text-gray-400">{axis}</span>
+                </div>
+                <p className="mt-1 text-xs text-gray-500 leading-relaxed min-h-[80px]">{why}</p>
+              </div>
+              <div className="w-[375px] max-w-full mx-auto rounded-[2rem] border-[6px] border-gray-900 bg-gray-50 shadow-xl overflow-hidden">
+                <div className="h-6 bg-gray-900 flex items-center justify-center">
+                  <div className="w-16 h-3 rounded-full bg-black" />
+                </div>
+                <div className="h-[660px] overflow-y-auto overscroll-contain">
+                  <Component data={scenario} onAction={onAction} />
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <section className="mt-8 max-w-[700px] mx-auto rounded-xl bg-white border border-gray-200 p-4 text-xs text-gray-600 leading-relaxed">
+          <h2 className="text-sm font-semibold text-gray-900 mb-2">Judging V</h2>
+          <ul className="space-y-1.5 list-disc pl-4">
+            <li>
+              Step the beats: the page dims and refocuses under each sentence; beat 2 spotlights the fold,
+              beat 3 relights the three rescue words the prose names.
+            </li>
+            <li>
+              <strong>Flip the toggle</strong>: every sentence rewrites itself; the fold moves; healthy beat 2
+              becomes a small brag.
+            </li>
+            <li>
+              In production, the beats would play once on open (or only after an absence), then settle into
+              the quiet fold view — the stepper is for judging all three states here.
+            </li>
+          </ul>
+        </section>
+      </main>
+
+      {actions.length > 0 && (
+        <div className="fixed bottom-4 left-4 z-[60] w-[300px] rounded-xl bg-gray-900 text-white shadow-2xl px-4 py-3" data-feedback-ui="true">
+          <div className="text-[10px] font-mono tracking-widest text-gray-400 mb-1.5">→ SENT TO TUTOR CHAT</div>
+          {actions.map((a, i) => (
+            <div key={i} className={cn("text-xs font-mono py-0.5", i === 0 ? "text-green-400" : "text-gray-500")}>
+              “{a}”
+            </div>
+          ))}
+        </div>
+      )}
+
+      <FeedbackOverlay targetName="ProgressPanel" />
+    </div>
+  );
+}


### PR DESCRIPTION
## What

A temporary design-exploration route at `/design-lab` for redesigning the V2 tutor's `ProgressPanel`. Nine rounds of iteration (dot-matrix fields, review orbits, gravity dunes, synapse networks, fading pages) converged on **the fold**:

- Your actual vocabulary words, sorted strongest → weakest, so reading order is the memory axis
- Fade encoded by **font weight → opacity → blur** (weight is a precise typographic data channel — Brath, *Visualizing with Text*; blur stays capped so ghosts read intentional)
- An amber dashed **fold** where the asleep (overdue) words begin: `THE FOLD · 126 ASLEEP BELOW`
- **Hover** previews a word (pure `transform: scale` — no line re-wrapping); **click/tap** sends `Quiz me on "…"` straight to the tutor chat
- Due words get **guaranteed slots** (capped at 16), so the fold surfaces what needs you even at 1000+ learned words
- Sits on a shared "mission control" chassis: recovery plan sized in minutes → streak/today/week → the fold

## Why

The current panel is a mirror, not a lever: under a backlog it renders 126 identical red 0% rows (demoralizing, uninformative) and offers no actions. The fold makes decay visible in the learner's own words and makes every word a door into the chat tutor.

## Reviewer notes

- Open `/design-lab` with the dev server running; flip the **Backlog / Healthy** toggle — the backlog state is the real test
- Everything is fixture-driven (`fixtures.ts`, two scenarios); no live data touched
- This route + `.claude-design/` are scaffolding and will be deleted by the follow-up PR that implements the fold in `app/v2/components/ProgressPanel.tsx`
- The lab page unregisters the offline service worker on load (see #22/#25 for the underlying dev-caching fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)