### PR TITLE
Add Openverse-backed image bank curation for the V2 tutor

### DIFF
--- a/app/(main)/admin/images/page.tsx
+++ b/app/(main)/admin/images/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Check, ExternalLink, Loader2, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface MissingConcept {
+  concept: string;
+  wordCount: number;
+}
+
+interface Candidate {
+  id: string;
+  title: string | null;
+  creator: string | null;
+  license: string;
+  licenseVersion: string | null;
+  licenseUrl: string | null;
+  url: string;
+  thumbnail: string;
+  attribution: string | null;
+  sourceUrl: string | null;
+}
+
+function licenseLabel(candidate: Pick<Candidate, "license" | "licenseVersion">) {
+  const name = candidate.license === "cc0" ? "CC0" : `CC ${candidate.license.toUpperCase()}`;
+  return candidate.licenseVersion ? `${name} ${candidate.licenseVersion}` : name;
+}
+
+export default function AdminImagesPage() {
+  const [missing, setMissing] = useState<MissingConcept[]>([]);
+  const [bankSize, setBankSize] = useState<number | null>(null);
+  const [isLoadingMissing, setIsLoadingMissing] = useState(true);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [searchOverride, setSearchOverride] = useState("");
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [savingUrl, setSavingUrl] = useState<string | null>(null);
+  const [justSaved, setJustSaved] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadMissing() {
+      try {
+        const response = await fetch("/api/v2/images");
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error ?? "Request failed");
+        setMissing(data.missing ?? []);
+        setBankSize(data.bankSize ?? null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Loading words failed");
+      } finally {
+        setIsLoadingMissing(false);
+      }
+    }
+    loadMissing();
+  }, []);
+
+  const search = useCallback(async (query: string) => {
+    setIsSearching(true);
+    setCandidates([]);
+    setError(null);
+    try {
+      const response = await fetch(`/api/v2/images/discover?concept=${encodeURIComponent(query)}`);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error ?? "Request failed");
+      setCandidates(data.candidates ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Image search failed");
+    } finally {
+      setIsSearching(false);
+    }
+  }, []);
+
+  const selectConcept = useCallback(
+    (concept: string) => {
+      setSelected(concept);
+      setSearchOverride("");
+      setJustSaved(null);
+      search(concept);
+    },
+    [search]
+  );
+
+  async function pick(candidate: Candidate) {
+    if (!selected || savingUrl) return;
+    setSavingUrl(candidate.url);
+    setError(null);
+    try {
+      const response = await fetch("/api/v2/images", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          concept: selected,
+          url: candidate.url,
+          license: candidate.license,
+          attribution: candidate.attribution,
+          sourceUrl: candidate.sourceUrl,
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error ?? "Request failed");
+
+      const remaining = missing.filter((m) => m.concept !== selected);
+      setMissing(remaining);
+      setBankSize((size) => (size === null ? size : size + 1));
+      setJustSaved(selected);
+      setCandidates([]);
+      // Move straight to the next word so curation flows without extra clicks.
+      const next = remaining[0]?.concept ?? null;
+      if (next) {
+        selectConcept(next);
+      } else {
+        setSelected(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Saving image failed");
+    } finally {
+      setSavingUrl(null);
+    }
+  }
+
+  return (
+    <div className="p-4 pt-12 max-w-5xl mx-auto">
+      <div className="flex items-baseline justify-between mb-1">
+        <h1 className="text-lg font-semibold">Image bank</h1>
+        {bankSize !== null && (
+          <span className="text-sm text-gray-400">{bankSize.toLocaleString()} images in the bank</span>
+        )}
+      </div>
+      <p className="text-sm text-gray-500 mb-6">
+        Words without a review-card image, with photo suggestions from Openverse. Only CC0, CC BY and
+        CC BY-SA photos are offered; attribution is saved with each pick.
+      </p>
+
+      {error && (
+        <div className="mb-4 text-sm text-red-600 bg-red-50 border border-red-100 rounded-xl px-4 py-3">
+          {error}
+        </div>
+      )}
+
+      {justSaved && (
+        <div className="mb-4 flex items-center gap-2 text-sm text-emerald-700 bg-emerald-50 border border-emerald-100 rounded-xl px-4 py-3">
+          <Check className="w-4 h-4" />
+          Image saved for “{justSaved}”
+        </div>
+      )}
+
+      <div className="grid md:grid-cols-[240px_1fr] gap-6 items-start">
+        {/* Words missing an image */}
+        <div className="bg-white border rounded-2xl overflow-hidden">
+          <div className="px-4 py-3 border-b text-sm text-gray-500">
+            {isLoadingMissing ? "Loading words…" : `${missing.length} words without an image`}
+          </div>
+          <div className="max-h-[32rem] overflow-y-auto">
+            {isLoadingMissing ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="w-5 h-5 animate-spin text-gray-400" />
+              </div>
+            ) : missing.length === 0 ? (
+              <div className="px-4 py-8 text-sm text-gray-400 text-center">
+                Every word has an image
+              </div>
+            ) : (
+              missing.map((item) => (
+                <button
+                  key={item.concept}
+                  onClick={() => selectConcept(item.concept)}
+                  className={`w-full text-left px-4 py-2.5 text-sm flex items-center justify-between gap-2 border-b last:border-b-0 transition-colors ${
+                    selected === item.concept ? "bg-gray-100" : "hover:bg-gray-50"
+                  }`}
+                >
+                  <span className="truncate">{item.concept}</span>
+                  {item.wordCount > 1 && (
+                    <span className="text-xs text-gray-400 shrink-0">{item.wordCount} words</span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Candidates */}
+        <div className="bg-white border rounded-2xl p-5 min-h-[16rem]">
+          {!selected ? (
+            <div className="flex items-center justify-center h-48 text-sm text-gray-400">
+              Pick a word to see photo suggestions
+            </div>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                <h2 className="text-base font-medium">Photos for “{selected}”</h2>
+                <form
+                  className="flex items-center gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    if (searchOverride.trim()) search(searchOverride.trim());
+                  }}
+                >
+                  <Input
+                    value={searchOverride}
+                    onChange={(event) => setSearchOverride(event.target.value)}
+                    placeholder="Try different search words"
+                    className="h-9 w-56"
+                  />
+                  <Button type="submit" size="sm" variant="outline" disabled={isSearching}>
+                    <Search className="w-4 h-4 mr-1" /> Search
+                  </Button>
+                </form>
+              </div>
+
+              {isSearching ? (
+                <div className="flex justify-center py-12">
+                  <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+                </div>
+              ) : candidates.length === 0 ? (
+                <div className="text-sm text-gray-400 py-12 text-center">
+                  No photos found — try different search words above
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                  {candidates.map((candidate) => (
+                    <div key={candidate.id} className="group">
+                      <button
+                        onClick={() => pick(candidate)}
+                        disabled={savingUrl !== null}
+                        className="relative w-full aspect-square rounded-xl overflow-hidden border bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-400 disabled:opacity-70"
+                        title="Use this photo"
+                      >
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={candidate.thumbnail}
+                          alt={candidate.title ?? selected}
+                          className="w-full h-full object-cover transition-transform group-hover:scale-[1.02]"
+                          loading="lazy"
+                        />
+                        {savingUrl === candidate.url && (
+                          <span className="absolute inset-0 flex items-center justify-center bg-white/70">
+                            <Loader2 className="w-5 h-5 animate-spin text-gray-500" />
+                          </span>
+                        )}
+                      </button>
+                      <div className="mt-1.5 flex items-center justify-between gap-2 text-xs text-gray-500">
+                        <span className="truncate">
+                          {candidate.creator ? `${candidate.creator} · ` : ""}
+                          {licenseLabel(candidate)}
+                        </span>
+                        {candidate.sourceUrl && (
+                          <a
+                            href={candidate.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-gray-400 hover:text-gray-600 shrink-0"
+                            title="View source"
+                          >
+                            <ExternalLink className="w-3.5 h-3.5" />
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/v2/images/discover/route.ts
+++ b/app/api/v2/images/discover/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { errorMessage } from "@/app/api/utils";
+import { ALLOWED_LICENSES, getImageBankAccess, isAllowedLicense } from "../shared";
+
+// Searches Openverse (free, CC-licensed image API) for candidate photos for
+// a concept. Anonymous access is rate-limited but fine at curation volume.
+
+const OPENVERSE_URL = "https://api.openverse.org/v1/images/";
+
+interface OpenverseResult {
+  id: string;
+  title?: string;
+  creator?: string;
+  license: string;
+  license_version?: string;
+  license_url?: string;
+  url: string;
+  thumbnail?: string;
+  attribution?: string;
+  foreign_landing_url?: string;
+}
+
+export async function GET(req: Request) {
+  try {
+    const access = await getImageBankAccess(req);
+    if ("error" in access) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
+    const query = new URL(req.url).searchParams.get("concept")?.trim();
+    if (!query) {
+      return NextResponse.json({ error: "Missing concept" }, { status: 400 });
+    }
+
+    const params = new URLSearchParams({
+      q: query,
+      license: ALLOWED_LICENSES.join(","),
+      page_size: "12",
+    });
+    const response = await fetch(`${OPENVERSE_URL}?${params}`, {
+      headers: { "User-Agent": "YallaFlash/1.0 (https://yallaflash.com; image bank curation)" },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Openverse returned ${response.status}` },
+        { status: 502 }
+      );
+    }
+
+    const data = (await response.json()) as { results?: OpenverseResult[] };
+    // The license query param already filters, but the license gate is the
+    // whole point of this route -- re-check each result before returning it.
+    const candidates = (data.results ?? [])
+      .filter((r) => r.url && isAllowedLicense(r.license))
+      .slice(0, 8)
+      .map((r) => ({
+        id: r.id,
+        title: r.title ?? null,
+        creator: r.creator ?? null,
+        license: r.license,
+        licenseVersion: r.license_version ?? null,
+        licenseUrl: r.license_url ?? null,
+        url: r.url,
+        thumbnail: r.thumbnail ?? r.url,
+        attribution: r.attribution ?? null,
+        sourceUrl: r.foreign_landing_url ?? null,
+      }));
+
+    return NextResponse.json({ candidates });
+  } catch (error) {
+    console.error("[v2/images/discover]", error);
+    return NextResponse.json(
+      { error: `Image search failed: ${errorMessage(error)}` },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/v2/images/route.ts
+++ b/app/api/v2/images/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { errorMessage } from "@/app/api/utils";
+import { getImageBankAccess, isAllowedLicense } from "./shared";
+
+// GET  -> concepts (distinct word english) that have no bank image
+// POST -> add a picked image to the bank under its concept key
+
+export async function GET(req: Request) {
+  try {
+    const access = await getImageBankAccess(req);
+    if ("error" in access) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
+    const [imagesRes, wordsRes] = await Promise.all([
+      access.serviceClient.from("v2_images").select("concept").limit(10000),
+      access.serviceClient.from("v2_words").select("english").limit(10000),
+    ]);
+    if (imagesRes.error) throw imagesRes.error;
+    if (wordsRes.error) throw wordsRes.error;
+
+    const bank = (imagesRes.data ?? []).map((row) => row.concept as string);
+    const bankSet = new Set(bank);
+
+    // Mirrors findImageForWord in app/v2/lib/tools.ts: a word is covered if
+    // its concept matches exactly or appears as a substring of a bank concept.
+    const hasImage = (english: string) => {
+      const concept = english.toLowerCase().trim();
+      if (bankSet.has(concept)) return true;
+      const safeConcept = concept.replace(/[,()%_]/g, " ").trim();
+      if (!safeConcept) return false;
+      return bank.some((c) => c.includes(safeConcept));
+    };
+
+    const wordCounts = new Map<string, number>();
+    for (const row of wordsRes.data ?? []) {
+      const english = (row.english as string | null) ?? "";
+      const concept = english.toLowerCase().trim();
+      if (!concept || hasImage(english)) continue;
+      wordCounts.set(concept, (wordCounts.get(concept) ?? 0) + 1);
+    }
+
+    const missing = Array.from(wordCounts.entries())
+      .map(([concept, wordCount]) => ({ concept, wordCount }))
+      .sort((a, b) => b.wordCount - a.wordCount || a.concept.localeCompare(b.concept));
+
+    return NextResponse.json({ missing, bankSize: bank.length });
+  } catch (error) {
+    console.error("[v2/images GET]", error);
+    return NextResponse.json(
+      { error: `Loading image bank failed: ${errorMessage(error)}` },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const access = await getImageBankAccess(req);
+    if ("error" in access) {
+      return NextResponse.json({ error: access.error }, { status: access.status });
+    }
+
+    const body = (await req.json()) as {
+      concept?: unknown;
+      url?: unknown;
+      license?: unknown;
+      attribution?: unknown;
+      sourceUrl?: unknown;
+    };
+
+    const concept = typeof body.concept === "string" ? body.concept.toLowerCase().trim() : "";
+    const url = typeof body.url === "string" ? body.url.trim() : "";
+    if (!concept || !/^https?:\/\//.test(url)) {
+      return NextResponse.json({ error: "Missing concept or image url" }, { status: 400 });
+    }
+    if (!isAllowedLicense(body.license)) {
+      return NextResponse.json(
+        { error: "Only cc0, by, and by-sa licensed images can be added" },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await access.serviceClient
+      .from("v2_images")
+      .upsert(
+        {
+          concept,
+          url,
+          source: "openverse",
+          license: body.license,
+          attribution: typeof body.attribution === "string" ? body.attribution : null,
+          source_url: typeof body.sourceUrl === "string" ? body.sourceUrl : null,
+        },
+        { onConflict: "concept" }
+      )
+      .select()
+      .single();
+    if (error) throw error;
+
+    return NextResponse.json({ image: data });
+  } catch (error) {
+    console.error("[v2/images POST]", error);
+    return NextResponse.json(
+      { error: `Saving image failed: ${errorMessage(error)}` },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/v2/images/shared.ts
+++ b/app/api/v2/images/shared.ts
@@ -1,0 +1,44 @@
+import { createClient as createServiceClient, SupabaseClient } from "@supabase/supabase-js";
+import { getApiAuth } from "@/utils/supabase/api";
+
+// Licenses we accept into the bank: public domain or attribution-style only.
+// These are Openverse license slugs.
+export const ALLOWED_LICENSES = ["cc0", "by", "by-sa"] as const;
+
+export function isAllowedLicense(license: unknown): license is (typeof ALLOWED_LICENSES)[number] {
+  return typeof license === "string" && (ALLOWED_LICENSES as readonly string[]).includes(license);
+}
+
+// Curating the image bank is admin/reviewer work. The bank has no per-user
+// rows (RLS only grants SELECT), and the words-without-images listing spans
+// every user's custom words, so after the role check both reads and writes
+// go through the service role.
+export async function getImageBankAccess(
+  req: Request
+): Promise<{ error: string; status: number } | { serviceClient: SupabaseClient }> {
+  const { supabase, user } = await getApiAuth(req);
+  if (!user) {
+    return { error: "Authentication required", status: 401 };
+  }
+
+  const { data: roleData } = await supabase
+    .from("user_roles")
+    .select("role")
+    .eq("user_id", user.id)
+    .single();
+  if (roleData?.role !== "admin" && roleData?.role !== "reviewer") {
+    return { error: "Admin or reviewer role required", status: 403 };
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { error: "Server configuration error", status: 500 };
+  }
+
+  return {
+    serviceClient: createServiceClient(supabaseUrl, serviceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    }),
+  };
+}

--- a/app/components/admin/AdminWrapper.tsx
+++ b/app/components/admin/AdminWrapper.tsx
@@ -42,6 +42,7 @@ export function AdminWrapper({ children }: { children: React.ReactNode }) {
   if (pathname.includes("/users")) activeTab = "users";
   else if (pathname.includes("/review")) activeTab = "review";
   else if (pathname.includes("/packs")) activeTab = "packs";
+  else if (pathname.includes("/images")) activeTab = "images";
   else if (pathname.includes("/songs")) activeTab = "songs";
   else if (pathname.includes("/instagram")) activeTab = "instagram";
   else if (pathname.includes("/design-system")) activeTab = "design-system";
@@ -55,6 +56,7 @@ export function AdminWrapper({ children }: { children: React.ReactNode }) {
     { key: "review", label: "Review", href: "/admin/review" },
     ...(isAdmin || isReviewer ? [
       { key: "packs", label: "Packs", href: "/admin/packs" },
+      { key: "images", label: "Images", href: "/admin/images" },
     ] : []),
     { key: "songs", label: "Songs", href: "/admin/songs" },
     ...(isAdmin ? [

--- a/supabase/migrations/20260707_v2_images_openverse.sql
+++ b/supabase/migrations/20260707_v2_images_openverse.sql
@@ -1,0 +1,10 @@
+-- Attribution metadata for bank images sourced from Openverse (CC-licensed
+-- photos). License is the Openverse slug (cc0, by, by-sa); attribution is the
+-- ready-made credit string Openverse provides; source_url points back to the
+-- original page on the provider (Flickr, Wikimedia, ...). Seed/Recraft images
+-- predate these columns and leave them null.
+
+ALTER TABLE v2_images
+  ADD COLUMN license TEXT,
+  ADD COLUMN attribution TEXT,
+  ADD COLUMN source_url TEXT;


### PR DESCRIPTION
## What

Adds an admin flow to populate the `v2_images` bank (the shared, concept-keyed image bank used by V2 review cards) with real CC-licensed photos from the [Openverse API](https://api.openverse.org/v1/images/).

- **`GET /api/v2/images`** — lists concepts (word English) that have no bank image. Matching mirrors the exact-then-substring logic of `findImageForWord` in `app/v2/lib/tools.ts`, so the list agrees with what the tutor actually shows.
- **`GET /api/v2/images/discover?concept=…`** — searches Openverse and returns up to 8 candidates (thumbnail, full-size url, license, creator, ready-made attribution string, source page link). Only cc0 / by / by-sa licenses are accepted, and each result's license is re-checked server-side rather than trusting the query param filter.
- **`POST /api/v2/images`** — validates the license against the same allowlist and upserts the pick under its lowercase concept key with `source: 'openverse'`, license, attribution, and source URL.
- **`/admin/images`** page (new "Images" tab next to Packs): left pane lists words missing images sorted by word count; clicking one shows a photo grid with creator/license captions and source links; clicking a photo saves it and auto-advances to the next word. A "try different search words" field re-searches for concepts that search poorly (e.g. "i go up") while still saving under the original concept key.

## Why

Many words have no bank image, so their review cards render without one. Openverse is free, needs no API key at curation volume, and provides ready-made attribution strings.

## Notes for review

- **Migration required before saves work:** `supabase/migrations/20260707_v2_images_openverse.sql` adds `license`, `attribution`, `source_url` to `v2_images`. Until it runs, picks fail with a clean inline error (verified).
- All three routes are admin/reviewer-gated (same role check as `app/api/admin/stats`) and then use the service-role client, since `v2_images` has only a SELECT RLS policy and the missing-words listing spans every user's custom words.
- Verified in the browser against live data: page loads (42 bank images, 879 words missing), "car" returns 8 CC-licensed photos rendering with attribution captions, and the save path was exercised end to end up to the DB write.
- UI text is sentence case throughout, per the style guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)