### PR TITLE
Stream AI responses for hints and sentences, polish generation UI

### DIFF
--- a/app/api/generate-hint/route.ts
+++ b/app/api/generate-hint/route.ts
@@ -1,9 +1,8 @@
-import { NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/server";
 import { cookies } from "next/headers";
 import { ClaudeService } from "@/app/services/claudeService";
 import { checkAIUsage, incrementUsage } from "@/app/services/aiUsageService";
-import { handleApiError, validateRequest } from "../utils";
+import { validateRequest } from "../utils";
 
 type HintRequest = {
   english: string;
@@ -14,19 +13,17 @@ export async function POST(req: Request) {
   try {
     const supabase = await createClient(cookies());
 
-    // Check authentication
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
-      return NextResponse.json(
+      return Response.json(
         { error: "Authentication required" },
         { status: 401 }
       );
     }
 
-    // Check AI usage limits
     const usageCheck = await checkAIUsage(user.id);
     if (!usageCheck.allowed) {
-      return NextResponse.json(
+      return Response.json(
         { error: usageCheck.reason, limitReached: true },
         { status: 429 }
       );
@@ -35,7 +32,7 @@ export async function POST(req: Request) {
     const data = await req.json();
 
     if (!validateRequest<HintRequest>(data, ["english", "arabic"])) {
-      return NextResponse.json(
+      return Response.json(
         { error: "Both English and Arabic words are required" },
         { status: 400 }
       );
@@ -59,13 +56,38 @@ Examples of good hints:
 
 Provide ONLY the hint text.`;
 
-    const hint = await ClaudeService.chatCompletion(prompt);
+    const stream = ClaudeService.createStreamingMessage(prompt);
 
-    // Increment usage after successful AI call
-    await incrementUsage(user.id);
+    incrementUsage(user.id);
 
-    return NextResponse.json({ hint });
-  } catch (error) {
-    return handleApiError(error, "Failed to generate hint");
+    const encoder = new TextEncoder();
+    const readable = new ReadableStream({
+      async start(controller) {
+        const reader = stream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            controller.enqueue(encoder.encode(value));
+          }
+          controller.close();
+        } catch (error) {
+          controller.error(error);
+        }
+      },
+    });
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Transfer-Encoding": "chunked",
+        "Cache-Control": "no-cache",
+      },
+    });
+  } catch {
+    return Response.json(
+      { error: "Failed to generate hint" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/generate-sentence/route.ts
+++ b/app/api/generate-sentence/route.ts
@@ -95,7 +95,19 @@ export async function POST(req: Request) {
     const sentence = await ClaudeService.generateSentence(word, english, type, notes, existingData);
     await incrementUsage(user.id);
     return Response.json(sentence);
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      return Response.json(
+        { error: "Request timed out" },
+        { status: 408 }
+      );
+    }
+    if (error instanceof Error && error.message.includes("parse")) {
+      return Response.json(
+        { error: "Invalid response from AI service" },
+        { status: 500 }
+      );
+    }
     return Response.json(
       { error: "Failed to generate sentence" },
       { status: 500 }

--- a/app/api/generate-sentence/route.ts
+++ b/app/api/generate-sentence/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from 'next/server';
 import { createClient } from "@/utils/supabase/server";
 import { cookies } from "next/headers";
-import { ClaudeService } from '@/app/services/claudeService';
-import { checkAIUsage, incrementUsage } from '@/app/services/aiUsageService';
-import { handleApiError, validateRequest } from '../utils';
+import { ClaudeService } from "@/app/services/claudeService";
+import { checkAIUsage, incrementUsage } from "@/app/services/aiUsageService";
+import { validateRequest } from "../utils";
+import { TransliterationService } from "@/app/services/transliterationService";
 
 type SentenceRequest = {
   word: string;
@@ -21,19 +21,17 @@ export async function POST(req: Request) {
   try {
     const supabase = await createClient(cookies());
 
-    // Check authentication
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
-      return NextResponse.json(
-        { error: 'Authentication required' },
+      return Response.json(
+        { error: "Authentication required" },
         { status: 401 }
       );
     }
 
-    // Check AI usage limits
     const usageCheck = await checkAIUsage(user.id);
     if (!usageCheck.allowed) {
-      return NextResponse.json(
+      return Response.json(
         { error: usageCheck.reason, limitReached: true },
         { status: 429 }
       );
@@ -41,22 +39,153 @@ export async function POST(req: Request) {
 
     const data = await req.json();
 
-    if (!validateRequest<SentenceRequest>(data, ['word'])) {
-      return NextResponse.json(
-        { error: 'Word is required' },
+    if (!validateRequest<SentenceRequest>(data, ["word"])) {
+      return Response.json(
+        { error: "Word is required" },
         { status: 400 }
       );
     }
 
     const { word, english, type, notes, existingData } = data;
+    const isStreaming = req.headers.get("Accept") === "text/event-stream";
+
+    if (isStreaming) {
+      const transliterationPrompt = await TransliterationService.getTransliterationPrompt();
+      const prompt = buildPrompt(word, english, type, notes, existingData, transliterationPrompt);
+      const stream = ClaudeService.createStreamingMessage(prompt);
+
+      incrementUsage(user.id);
+
+      const encoder = new TextEncoder();
+      let accumulated = "";
+
+      const readable = new ReadableStream({
+        async start(controller) {
+          const reader = stream.getReader();
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              accumulated += value;
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ chunk: value, partial: accumulated })}\n\n`));
+            }
+            try {
+              const jsonMatch = accumulated.match(/\{[\s\S]*\}/);
+              const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : JSON.parse(accumulated);
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true, result: parsed })}\n\n`));
+            } catch {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: "Invalid response format" })}\n\n`));
+            }
+            controller.close();
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+      });
+
+      return new Response(readable, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    }
 
     const sentence = await ClaudeService.generateSentence(word, english, type, notes, existingData);
-
-    // Increment usage after successful AI call
     await incrementUsage(user.id);
-
-    return NextResponse.json(sentence);
-  } catch (error) {
-    return handleApiError(error, 'Failed to generate sentence');
+    return Response.json(sentence);
+  } catch {
+    return Response.json(
+      { error: "Failed to generate sentence" },
+      { status: 500 }
+    );
   }
+}
+
+function buildPrompt(
+  word: string,
+  english?: string,
+  type?: string,
+  notes?: string,
+  existingData?: { arabic?: string; transliteration?: string; english?: string },
+  transliterationPrompt?: string
+): string {
+  const contextInfo = [];
+  if (type) contextInfo.push(`Word type: ${type}`);
+  if (notes) contextInfo.push(`Additional notes: ${notes}`);
+
+  const contextSection = contextInfo.length > 0
+    ? `\nContext information about the word:\n${contextInfo.join("\n")}\n`
+    : "";
+
+  const hasExistingEnglish = existingData?.english && existingData.english.trim().length > 0;
+  const hasExistingTransliteration = existingData?.transliteration && existingData.transliteration.trim().length > 0;
+  const hasExistingArabic = existingData?.arabic && existingData.arabic.trim().length > 0;
+
+  const existingFields = [];
+  if (hasExistingEnglish) existingFields.push(`English: "${existingData!.english}"`);
+  if (hasExistingTransliteration) existingFields.push(`Transliteration: "${existingData!.transliteration}"`);
+  if (hasExistingArabic) existingFields.push(`Arabic: "${existingData!.arabic}"`);
+
+  const existingSection = existingFields.length > 0
+    ? `\nProvided sentence parts:\n${existingFields.join("\n")}\n`
+    : "";
+
+  if (existingFields.length > 0) {
+    return `You are an AI assistant specialized in Lebanese Arabic language education. Your task is to complete or gently correct an example sentence.
+
+Word to include: "${word}"${contextSection}${existingSection}
+
+Your task:
+1. If all three fields are provided, make only minimal corrections if there are obvious errors
+2. If some fields are missing, generate them based on the provided ones
+3. Ensure the word "${word}" appears naturally in the sentence
+4. Keep as close as possible to the provided content - only change what's necessary
+
+Guidelines:
+- Preserve the original meaning and structure when possible
+- Only correct clear grammatical errors or unnatural phrasing
+- Ensure consistency between all three versions (Arabic, transliteration, English)
+- Be culturally appropriate
+
+${transliterationPrompt || ""}
+
+Return ONLY a JSON object with this exact structure:
+{
+  "arabic": "${hasExistingArabic ? existingData!.arabic : "The sentence in Arabic script"}",
+  "transliteration": "${hasExistingTransliteration ? existingData!.transliteration : "The Lebanese Arabic pronunciation"}",
+  "english": "${hasExistingEnglish ? existingData!.english : "The English translation"}"
+}
+
+Fill in any missing fields and make minimal corrections to existing ones if needed.
+No additional text or explanations. Just the JSON.`;
+  }
+
+  const meaningContext = english ? `\nEnglish meaning: "${english}"` : "";
+
+  return `You are an AI assistant specialized in Lebanese Arabic language education. Your task is to generate an example sentence using a given Arabic word.
+
+Arabic word: "${word}"${meaningContext}${contextSection}
+
+Create a simple, clear example sentence in Lebanese Arabic that uses this word naturally.
+
+Guidelines:
+- Keep the sentence short and simple (5-10 words)
+- Use ONLY common, everyday vocabulary (water, food, house, go, come, want, have, good, bad, big, small, etc.)
+- Ensure the sentence is grammatically correct and natural in Lebanese Arabic
+- Use the context provided to choose the correct meaning if the word has multiple meanings
+- Be culturally appropriate
+- Vary sentence structures for creativity
+
+${transliterationPrompt || ""}
+
+Return ONLY a JSON object with this exact structure:
+{
+  "arabic": "The sentence in Arabic script",
+  "transliteration": "The Lebanese Arabic pronunciation",
+  "english": "The English translation"
+}
+
+No additional text or explanations. Just the JSON.`;
 }

--- a/app/components/SentenceGenerator.tsx
+++ b/app/components/SentenceGenerator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { CircleNotch, MagicWand, WarningCircle } from "@phosphor-icons/react";
+import { MagicWand, WarningCircle, Sparkle } from "@phosphor-icons/react";
 import {
   Tooltip,
   TooltipContent,
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { useAIUsage } from "../hooks/useAIUsage";
+import { motion, AnimatePresence } from "framer-motion";
 
 interface SentenceGeneratorProps {
   word: {
@@ -31,8 +32,11 @@ interface GeneratedSentence {
   transliteration: string;
 }
 
+type StreamState = "idle" | "streaming" | "done" | "error";
+
 export default function SentenceGenerator({ word }: SentenceGeneratorProps) {
-  const [isGenerating, setIsGenerating] = useState(false);
+  const [streamState, setStreamState] = useState<StreamState>("idle");
+  const [streamedText, setStreamedText] = useState("");
   const [sentence, setSentence] = useState<GeneratedSentence | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [limitReached, setLimitReached] = useState(false);
@@ -40,57 +44,108 @@ export default function SentenceGenerator({ word }: SentenceGeneratorProps) {
   const { toast } = useToast();
   const { refresh: refreshUsage } = useAIUsage();
 
-  React.useEffect(() => {
-    const generateSentence = async () => {
-      setIsGenerating(true);
+  const generateSentence = useCallback(async () => {
+    setStreamState("streaming");
+    setStreamedText("");
+    setError(null);
+    setLimitReached(false);
+    setSentence(null);
+
+    try {
+      const response = await fetch("/api/generate-sentence", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+        },
+        body: JSON.stringify({
+          word: word.arabic,
+          english: word.english,
+          type: word.type,
+          notes: word.notes,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        if (errorData.limitReached) {
+          setLimitReached(true);
+          setError(errorData.error || "Monthly AI limit reached");
+          setStreamState("error");
+          return;
+        }
+        throw new Error(errorData.error || "Failed to generate sentence");
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error("No response stream");
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.chunk) {
+              setStreamedText((prev) => prev + data.chunk);
+            }
+            if (data.done && data.result) {
+              setSentence(data.result);
+              setStreamState("done");
+              refreshUsage();
+            }
+            if (data.error) {
+              throw new Error(data.error);
+            }
+          } catch (e) {
+            if (e instanceof SyntaxError) continue;
+            throw e;
+          }
+        }
+      }
+
+      if (streamState !== "done") {
+        setStreamState("done");
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to generate sentence. Please try again."
+      );
+      setStreamState("error");
+      toast({
+        variant: "destructive",
+        title: "Failed to generate sentence",
+      });
+    }
+  }, [word, refreshUsage, toast, streamState]);
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (open) {
+      generateSentence();
+    } else {
+      setStreamState("idle");
+      setStreamedText("");
+      setSentence(null);
       setError(null);
       setLimitReached(false);
-
-      try {
-        const response = await fetch("/api/generate-sentence", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            word: word.arabic,
-            english: word.english,
-            type: word.type,
-            notes: word.notes,
-          }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-          if (errorData.limitReached) {
-            setLimitReached(true);
-            setError(errorData.error || "Monthly AI limit reached");
-            return;
-          }
-          throw new Error(errorData.error || "Failed to generate sentence");
-        }
-
-        const data = await response.json();
-        setSentence(data);
-        refreshUsage();
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to generate sentence. Please try again.");
-        toast({
-          variant: "destructive",
-          title: "Failed to generate sentence",
-        });
-      } finally {
-        setIsGenerating(false);
-      }
-    };
-
-    if (isOpen && !sentence && !isGenerating && !limitReached) {
-      generateSentence();
     }
-  }, [isOpen, sentence, isGenerating, limitReached, word, refreshUsage, toast]);
+  };
+
+  const displaySentence = sentence;
+  const isStreaming = streamState === "streaming";
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DialogTrigger asChild>
@@ -106,64 +161,127 @@ export default function SentenceGenerator({ word }: SentenceGeneratorProps) {
         </TooltipTrigger>
         <TooltipContent>Generate a sentence</TooltipContent>
       </Tooltip>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>
+      <DialogContent className="sm:max-w-[440px] gap-0 overflow-hidden">
+        <DialogHeader className="pb-4">
+          <DialogTitle className="text-base">
             Example sentence with &quot;{word.arabic}&quot;
           </DialogTitle>
         </DialogHeader>
 
-        <div className="relative min-h-28">
-          <div
-            className={`absolute inset-0 flex items-center justify-center transition-opacity duration-500 ${
-              isGenerating ? "opacity-100" : "opacity-0"
-            }`}
-          >
-            <div className="relative ">
-              <div className="absolute inset-[-30px] rounded-full bg-gradient-to-r from-violet-600/50 via-fuchsia-500/50 to-violet-600/50 animate-[pulse_2s_ease-in-out_infinite] blur-2xl" />
-              <div className="absolute inset-[-20px] rounded-full bg-gradient-to-r from-violet-400/40 via-fuchsia-400/40 to-violet-400/40 animate-[pulse_2s_ease-in-out_infinite_500ms] blur-xl" />
-              <div className="relative bg-gradient-to-r from-violet-500 via-fuchsia-500 to-violet-500 bg-clip-text text-transparent animate-[pulse_2s_ease-in-out_infinite_1000ms]">
-                <CircleNotch className="h-16 w-16 animate-spin" />
-              </div>
-            </div>
-          </div>
+        <div className="relative min-h-[120px]">
+          <AnimatePresence mode="wait">
+            {error && (
+              <motion.div
+                key="error"
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="flex items-center justify-center"
+              >
+                {limitReached ? (
+                  <div className="rounded-xl border border-rose-200 bg-rose-50 p-4 w-full">
+                    <div className="flex items-start gap-3">
+                      <WarningCircle className="h-5 w-5 text-rose-500 flex-shrink-0 mt-0.5" weight="fill" />
+                      <div className="text-sm">
+                        <p className="font-medium text-rose-800">Monthly limit reached</p>
+                        <p className="text-rose-700 mt-1">
+                          You&apos;ve used all your free AI generations this month. Your limit resets next month.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-center text-red-500 text-sm">{error}</div>
+                )}
+              </motion.div>
+            )}
 
-          {error && (
-            <div className="absolute inset-0 flex items-center justify-center">
-              {limitReached ? (
-                <div className="rounded-lg border border-rose-200 bg-rose-50 p-4 mx-4">
-                  <div className="flex items-start gap-3">
-                    <WarningCircle className="h-5 w-5 text-rose-500 flex-shrink-0 mt-0.5" weight="fill" />
-                    <div className="text-sm">
-                      <p className="font-medium text-rose-800">Monthly limit reached</p>
-                      <p className="text-rose-700 mt-1">
-                        You&apos;ve used all your free AI generations this month. Your limit resets next month.
+            {!error && (isStreaming || displaySentence) && (
+              <motion.div
+                key="content"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.2 }}
+                className="space-y-4"
+              >
+                {displaySentence ? (
+                  <div className="space-y-3">
+                    <motion.div
+                      initial={{ opacity: 0, y: 4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.3 }}
+                      className="rounded-xl bg-gradient-to-br from-violet-50 to-fuchsia-50 border border-violet-100 p-4"
+                    >
+                      <p className="text-2xl font-arabic leading-relaxed text-violet-950">
+                        {displaySentence.arabic}
+                      </p>
+                      <p className="text-sm text-violet-600 mt-1.5">
+                        {displaySentence.transliteration}
+                      </p>
+                    </motion.div>
+                    <motion.p
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      transition={{ duration: 0.3, delay: 0.1 }}
+                      className="text-sm font-medium text-body px-1"
+                    >
+                      {displaySentence.english}
+                    </motion.p>
+                  </div>
+                ) : (
+                  <div className="rounded-xl bg-gradient-to-br from-violet-50 to-fuchsia-50 border border-violet-100 p-4">
+                    <div className="flex items-start gap-2">
+                      <Sparkle className="h-4 w-4 text-violet-400 flex-shrink-0 mt-0.5 animate-pulse" weight="fill" />
+                      <p className="text-sm text-violet-700 leading-relaxed whitespace-pre-wrap">
+                        {streamedText}
+                        <motion.span
+                          className="inline-block w-[2px] h-[14px] bg-violet-400 ml-0.5 align-middle"
+                          animate={{ opacity: [1, 0] }}
+                          transition={{ duration: 0.5, repeat: Infinity, repeatType: "reverse" }}
+                        />
                       </p>
                     </div>
                   </div>
-                </div>
-              ) : (
-                <div className="text-center text-red-500 text-sm">{error}</div>
-              )}
-            </div>
-          )}
+                )}
+              </motion.div>
+            )}
 
-          <div
-            className={`transition-opacity duration-800 my-2 ${
-              sentence && !isGenerating ? "opacity-100" : "opacity-0"
-            }`}
-          >
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <div className="text-3xl font-arabic">{sentence?.arabic}</div>
-                <div className="text-sm text-muted-foreground">
-                  {sentence?.transliteration}
+            {!error && !isStreaming && !displaySentence && streamState === "idle" && (
+              <motion.div
+                key="loading"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="flex items-center justify-center h-[120px]"
+              >
+                <div className="relative">
+                  <div className="absolute inset-[-20px] rounded-full bg-gradient-to-r from-violet-600/30 via-fuchsia-500/30 to-violet-600/30 animate-pulse blur-xl" />
+                  <Sparkle className="h-10 w-10 text-violet-500 animate-pulse" weight="fill" />
                 </div>
-                <div className="text-sm font-medium">{sentence?.english}</div>
-              </div>
-            </div>
-          </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
+
+        {displaySentence && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2 }}
+            className="pt-3 flex justify-end"
+          >
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={generateSentence}
+              className="text-violet-600 hover:text-violet-700 hover:bg-violet-50"
+            >
+              <Sparkle className="h-3.5 w-3.5" weight="fill" />
+              Generate another
+            </Button>
+          </motion.div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/components/review/Review.tsx
+++ b/app/components/review/Review.tsx
@@ -18,7 +18,6 @@ import {
   SmileyNervous,
   Balloon,
   Lightbulb,
-  CircleNotch,
   NoteBlank,
 } from "@phosphor-icons/react";
 import { ArrowRight } from "lucide-react";
@@ -83,6 +82,7 @@ export function Review() {
 
     setIsLoadingHint(true);
     setHintError(null);
+    setHint("");
 
     try {
       const response = await fetch("/api/generate-hint", {
@@ -101,20 +101,36 @@ export function Review() {
         } else {
           setHintError("Failed to generate hint");
         }
+        setHint(null);
         return;
       }
 
-      const data = await response.json();
-      setHint(data.hint);
+      const reader = response.body?.getReader();
+      if (!reader) {
+        setHintError("Failed to generate hint");
+        setHint(null);
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let accumulated = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        accumulated += decoder.decode(value, { stream: true });
+        setHint(accumulated);
+      }
+
       refreshUsage();
     } catch {
       setHintError("Failed to generate hint");
+      setHint(null);
     } finally {
       setIsLoadingHint(false);
     }
   };
 
-  // Load the first word when component mounts (only once)
   useEffect(() => {
     if (!hasLoadedRef.current && session?.user) {
       hasLoadedRef.current = true;
@@ -122,7 +138,6 @@ export function Review() {
     }
   }, [loadNextWord, session?.user]);
 
-  // Fetch sentences when word changes
   useEffect(() => {
     if (currentWord?.id) {
       SentenceService.getSentencesForWord(currentWord.id).then(setSentences);
@@ -132,7 +147,6 @@ export function Review() {
   const handleRating = async (rating: number) => {
     if (!session?.user || !currentWord) return;
 
-    // Show feedback animation
     const feedbackText =
       rating === 0
         ? "Forgot"
@@ -171,10 +185,8 @@ export function Review() {
         )
     );
 
-    // Track review for funnel analysis
     posthog.capture("word_reviewed", { rating });
 
-    // Calculate next review time text
     let nextReviewText = "";
     if (result && result.nextReview) {
       const formattedTime = formatTimeUntilReview(
@@ -211,12 +223,10 @@ export function Review() {
     fetchReviewCount();
     window.dispatchEvent(new CustomEvent("wordProgressUpdated"));
 
-    // Clear animation to trigger exit, then load next word
     setTimeout(() => {
       setFeedbackAnimation({ isPlaying: false, text: "", color: "" });
     }, 600);
 
-    // Load next word after exit animation completes (skip loading skeleton)
     setTimeout(async () => {
       await loadNextWord(false);
     }, 800);
@@ -271,19 +281,30 @@ export function Review() {
             )}
           </AnimatePresence>
 
-          {/* Hint/Notes/Buttons - shown on front of card */}
           {currentWord && !isFlipped && (
             <AnimatePresence mode="wait">
-              {hint ? (
+              {hint !== null && hint.length > 0 ? (
                 <motion.div
                   key="hint"
-                  initial={{ opacity: 0, filter: "blur(4px)" }}
-                  animate={{ opacity: 1, filter: "blur(0px)" }}
-                  transition={{ duration: 0.15 }}
-                  className="absolute bottom-3 left-3 right-3 text-center text-sm text-body pointer-events-none"
+                  initial={{ opacity: 0, y: 4 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.2 }}
+                  className="absolute bottom-3 left-3 right-3 text-center pointer-events-none"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  {hint}
+                  <div className="inline-flex items-start gap-2 px-3 py-2 rounded-lg bg-amber-50 border border-amber-100">
+                    <Lightbulb className="h-3.5 w-3.5 text-amber-500 flex-shrink-0 mt-0.5" weight="fill" />
+                    <span className="text-sm text-amber-900 text-left leading-relaxed">
+                      {hint}
+                      {isLoadingHint && (
+                        <motion.span
+                          className="inline-block w-[2px] h-[14px] bg-amber-400 ml-0.5 align-middle"
+                          animate={{ opacity: [1, 0] }}
+                          transition={{ duration: 0.5, repeat: Infinity, repeatType: "reverse" }}
+                        />
+                      )}
+                    </span>
+                  </div>
                 </motion.div>
               ) : hintError ? (
                 <motion.div
@@ -325,17 +346,8 @@ export function Review() {
                     disabled={isLoadingHint}
                     className="rounded-full shadow-none"
                   >
-                    {isLoadingHint ? (
-                      <>
-                        <CircleNotch className="h-4 w-4 animate-spin" />
-                        Thinking...
-                      </>
-                    ) : (
-                      <>
-                        <Lightbulb className="h-4 w-4" />
-                        Get a hint
-                      </>
-                    )}
+                    <Lightbulb className="h-4 w-4" />
+                    Get a hint
                   </Button>
                   {currentWord.notes && (
                     <Button
@@ -357,7 +369,6 @@ export function Review() {
           )}
         </CardContent>
 
-          {/* Open button in bottom right of card */}
           {isFlipped && (
             <div className="absolute bottom-3 right-3 z-10">
               <Button
@@ -392,10 +403,8 @@ export function Review() {
                   ease: [0.23, 1, 0.32, 1],
                 }}
               >
-                {/* Gradient edge */}
                 <div className="absolute right-0 top-0 bottom-0 w-20 bg-gradient-to-r from-transparent to-black/10" />
 
-                {/* Text and icon */}
                 <motion.div
                   initial={{ scale: 0.8, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
@@ -423,7 +432,6 @@ export function Review() {
                     )}
                     <span className="text-2xl font-bold">{feedbackAnimation.text}</span>
                   </div>
-                  {/* Reserve space for next review text to prevent layout shift */}
                   <div className="mt-2 h-5">
                     <motion.div
                       initial={{ opacity: 0 }}
@@ -434,7 +442,7 @@ export function Review() {
                       }}
                       className="text-white/90 text-sm font-medium"
                     >
-                      {feedbackAnimation.nextReviewText || '\u00A0'}
+                      {feedbackAnimation.nextReviewText || ' '}
                     </motion.div>
                   </div>
                 </motion.div>
@@ -496,13 +504,12 @@ export function Review() {
         </motion.div>
       )}
 
-      {/* Example sentences */}
       {currentWord && isFlipped && sentences.length > 0 && (
         <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.15, delay: 0.1 }}
-          className="mt-6 p-4 bg-gray-50 rounded-xl"
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.25, delay: 0.1 }}
+          className="mt-6 p-4 bg-gray-50 rounded-xl border border-gray-100"
         >
           <p className="font-arabic text-lg mb-1">{sentences[0].arabic}</p>
           {sentences[0].transliteration && (

--- a/app/services/claudeService.ts
+++ b/app/services/claudeService.ts
@@ -22,12 +22,39 @@ export class ClaudeService {
       max_tokens: 1000,
       messages: [{ role: "user", content: prompt }],
     });
-    
+
     if (!message.content || message.content.length === 0) {
       throw new Error("No content in Claude response");
     }
-    
+
     return message.content[0].type === "text" ? message.content[0].text : "";
+  }
+
+  static createStreamingMessage(prompt: string): ReadableStream<string> {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error("ANTHROPIC_API_KEY is not configured");
+    }
+
+    return new ReadableStream({
+      async start(controller) {
+        try {
+          const stream = anthropic.messages.stream({
+            model: MODEL,
+            max_tokens: 1000,
+            messages: [{ role: "user", content: prompt }],
+          });
+
+          stream.on("text", (text) => {
+            controller.enqueue(text);
+          });
+
+          await stream.finalMessage();
+          controller.close();
+        } catch (error) {
+          controller.error(error);
+        }
+      },
+    });
   }
 
   static async chatCompletion(prompt: string): Promise<string> {


### PR DESCRIPTION
## Summary

- **Streaming hint generation**: During flashcard review, clicking "Get a hint" now streams text word-by-word instead of showing a spinner then revealing all at once. The hint appears inside a warm amber chip with a lightbulb icon and blinking cursor.
- **Streaming sentence generation**: The SentenceGenerator dialog streams the raw Claude response in real-time with a typing indicator, then cross-fades to a polished result card once the JSON is fully parsed. A "Generate another" button lets users re-roll without closing the dialog.
- **Design polish**: Sentence results displayed in a gradient card (violet-50 → fuchsia-50) with clear Arabic/transliteration/English hierarchy. Example sentences section gets a subtle border and slide-up entrance animation.

## Changes

- `app/services/claudeService.ts` — Added `createStreamingMessage()` method using `anthropic.messages.stream()`
- `app/api/generate-hint/route.ts` — Returns a chunked `text/plain` stream instead of JSON
- `app/api/generate-sentence/route.ts` — Supports SSE streaming when `Accept: text/event-stream` header is set, with backwards-compatible JSON fallback
- `app/components/review/Review.tsx` — Consumes streaming hint via `ReadableStream` reader, improved hint display with amber badge styling
- `app/components/SentenceGenerator.tsx` — Full rewrite with SSE consumption, streaming text preview, animated result card, and regenerate button

## Test plan

- [ ] Open a flashcard review session and click "Get a hint" — text should appear incrementally
- [ ] Click the magic wand on any word to generate a sentence — should see streaming text, then a styled result card
- [ ] Click "Generate another" to re-roll without closing the dialog
- [ ] Verify AI credit limit errors still display correctly (429 responses)
- [ ] Test on mobile — hint chip and sentence dialog should be responsive
- [ ] Verify the non-streaming JSON fallback still works for `ExampleSentenceManager` (no `Accept: text/event-stream` header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYZiPWwYb2kDqVU9dRbrzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYZiPWwYb2kDqVU9dRbrzJ)_