### PR TITLE
Stream tutor replies in the V2 chat

### DIFF
--- a/app/api/v2/chat/route.ts
+++ b/app/api/v2/chat/route.ts
@@ -144,84 +144,149 @@ export async function POST(req: Request) {
       }
     }
 
-    const widgets: Widget[] = [];
-    let finalText = "";
-    let lastStopReason: string | null = null;
+    // Hint-leak guard state is needed BEFORE the loop when streaming: raw
+    // deltas must be scrubbed as they're emitted, not just in the stored row.
+    const openCard = findOpenCard(rows);
 
-    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
-      const response = await anthropic.messages.create({
-        model: MODEL,
-        // Must fit a propose_words call for a long pasted list -- at 1024 the
-        // tool_use block gets truncated and silently dropped, so the reply
-        // text lands without its widget.
-        max_tokens: 4096,
-        system,
-        tools,
-        messages,
-      });
+    // The tool loop, shared by both response modes. onText receives the
+    // accumulated text of the CURRENT model call -- a later iteration's text
+    // replaces an earlier one's (same overwrite semantics as before).
+    const runLoop = async (onText?: (accumulated: string) => void) => {
+      const widgets: Widget[] = [];
+      let finalText = "";
+      let lastStopReason: string | null = null;
 
-      lastStopReason = response.stop_reason;
-      const toolUseBlocks = response.content.filter(
-        (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
-      );
-      finalText = response.content
-        .filter((block): block is Anthropic.TextBlock => block.type === "text")
-        .map((block) => block.text)
-        .join("\n");
+      for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+        const stream = anthropic.messages.stream({
+          model: MODEL,
+          // Must fit a propose_words call for a long pasted list -- at 1024 the
+          // tool_use block gets truncated and silently dropped, so the reply
+          // text lands without its widget.
+          max_tokens: 4096,
+          system,
+          tools,
+          messages,
+        });
 
-      if (toolUseBlocks.length === 0) break;
-
-      messages.push({ role: "assistant", content: response.content });
-
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
-      for (const block of toolUseBlocks) {
-        // A tool failure (bad input, transient DB error) goes back to the
-        // model as an error result it can react to, instead of 500ing the
-        // whole turn.
-        try {
-          const { result, widget } = await executeTool(ctx, block.name, block.input as Record<string, unknown>);
-          if (widget) widgets.push(widget);
-          toolResults.push({
-            type: "tool_result",
-            tool_use_id: block.id,
-            content: JSON.stringify(result),
-          });
-        } catch (error) {
-          console.error(`[v2/chat] tool ${block.name}`, error);
-          toolResults.push({
-            type: "tool_result",
-            tool_use_id: block.id,
-            content: errorMessage(error),
-            is_error: true,
+        if (onText) {
+          let accumulated = "";
+          stream.on("text", (delta) => {
+            accumulated += delta;
+            onText(accumulated);
           });
         }
+
+        const response = await stream.finalMessage();
+
+        lastStopReason = response.stop_reason;
+        const toolUseBlocks = response.content.filter(
+          (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+        );
+        finalText = response.content
+          .filter((block): block is Anthropic.TextBlock => block.type === "text")
+          .map((block) => block.text)
+          .join("\n");
+
+        if (toolUseBlocks.length === 0) break;
+
+        messages.push({ role: "assistant", content: response.content });
+
+        const toolResults: Anthropic.ToolResultBlockParam[] = [];
+        for (const block of toolUseBlocks) {
+          // A tool failure (bad input, transient DB error) goes back to the
+          // model as an error result it can react to, instead of 500ing the
+          // whole turn.
+          try {
+            const { result, widget } = await executeTool(ctx, block.name, block.input as Record<string, unknown>);
+            if (widget) widgets.push(widget);
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: block.id,
+              content: JSON.stringify(result),
+            });
+          } catch (error) {
+            console.error(`[v2/chat] tool ${block.name}`, error);
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: block.id,
+              content: errorMessage(error),
+              is_error: true,
+            });
+          }
+        }
+        messages.push({ role: "user", content: toolResults });
+
+        if (response.stop_reason !== "tool_use") break;
       }
-      messages.push({ role: "user", content: toolResults });
 
-      if (response.stop_reason !== "tool_use") break;
+      return { widgets, finalText, lastStopReason };
+    };
+
+    // Everything after the loop: max-tokens note, usage, leak guards,
+    // persistence. Shared by both response modes.
+    const finishTurn = async (loopResult: {
+      widgets: Widget[];
+      finalText: string;
+      lastStopReason: string | null;
+    }) => {
+      let { finalText } = loopResult;
+      const { widgets, lastStopReason } = loopResult;
+
+      // A truncated response can silently drop an incomplete tool_use block --
+      // if that killed the widget, at least tell the user what to do about it.
+      if (lastStopReason === "max_tokens" && widgets.length === 0) {
+        finalText = `${finalText}\n\nThat ran longer than I can handle in one go -- try pasting fewer words at a time.`.trim();
+      }
+
+      await incrementUsage(user.id, supabase);
+
+      // Hint-leak guard: while a served card is unanswered, a word_card for
+      // that word (e.g. from get_word_detail during a hint) would reveal the
+      // hidden side. Strip it deterministically -- prompts alone don't hold.
+      const safeWidgets = widgets.filter(
+        (w) => !(w.type === "word_card" && openCard && w.word.id === openCard.wordId)
+      );
+      // Same guard for the reply text: the model's natural way to reference the
+      // open card ("the 'l leyle' card is still waiting") names it by exactly
+      // the side the card is quizzing. Swap the hidden side for the shown one.
+      if (openCard) finalText = scrubOpenCardAnswer(finalText, openCard);
+
+      return insertMessage(supabase, conversationId, "assistant", finalText, safeWidgets);
+    };
+
+    // Streaming mode (opt-in via Accept header): text deltas ride an SSE
+    // stream as full-replace snapshots -- each event carries the whole text
+    // so far, already scrubbed, so a delta can never leak the open card's
+    // answer and iteration overwrites need no client bookkeeping.
+    if (req.headers.get("accept") === "text/event-stream") {
+      const encoder = new TextEncoder();
+      const readable = new ReadableStream({
+        async start(controller) {
+          const send = (event: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          try {
+            const loopResult = await runLoop((accumulated) => {
+              send({ type: "text", partial: streamSafeText(accumulated, openCard) });
+            });
+            const assistantMessage = await finishTurn(loopResult);
+            send({ type: "done", conversationId, message: assistantMessage });
+          } catch (error) {
+            console.error("[v2/chat]", error);
+            send({ type: "error", error: `Chat failed: ${errorMessage(error)}` });
+          }
+          controller.close();
+        },
+      });
+      return new Response(readable, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache, no-transform",
+          Connection: "keep-alive",
+        },
+      });
     }
 
-    // A truncated response can silently drop an incomplete tool_use block --
-    // if that killed the widget, at least tell the user what to do about it.
-    if (lastStopReason === "max_tokens" && widgets.length === 0) {
-      finalText = `${finalText}\n\nThat ran longer than I can handle in one go -- try pasting fewer words at a time.`.trim();
-    }
-
-    await incrementUsage(user.id, supabase);
-
-    // Hint-leak guard: while a served card is unanswered, a word_card for
-    // that word (e.g. from get_word_detail during a hint) would reveal the
-    // hidden side. Strip it deterministically -- prompts alone don't hold.
-    const openCard = findOpenCard(rows);
-    const safeWidgets = widgets.filter(
-      (w) => !(w.type === "word_card" && openCard && w.word.id === openCard.wordId)
-    );
-    // Same guard for the reply text: the model's natural way to reference the
-    // open card ("the 'l leyle' card is still waiting") names it by exactly
-    // the side the card is quizzing. Swap the hidden side for the shown one.
-    if (openCard) finalText = scrubOpenCardAnswer(finalText, openCard);
-
-    const assistantMessage = await insertMessage(supabase, conversationId, "assistant", finalText, safeWidgets);
+    const assistantMessage = await finishTurn(await runLoop());
     return NextResponse.json({ conversationId, message: assistantMessage });
   } catch (error) {
     // V2 is in active development for personal use: log the real error to
@@ -230,6 +295,25 @@ export async function POST(req: Request) {
     console.error("[v2/chat]", error);
     return NextResponse.json({ error: `Chat failed: ${errorMessage(error)}` }, { status: 500 });
   }
+}
+
+// Streaming-safe view of in-flight text: scrub completed mentions of the open
+// card's hidden side, and hold back any trailing PARTIAL match so the answer
+// can't flash on screen for a frame before the scrub catches it. Because
+// events are full-replace snapshots, held-back text is emitted (or scrubbed)
+// by a later snapshot -- nothing is lost.
+function streamSafeText(text: string, card: OpenCard | null): string {
+  if (!card || !card.hidden.trim()) return text;
+  const lower = text.toLowerCase();
+  const hidden = card.hidden.toLowerCase();
+  let cut = text.length;
+  for (let k = Math.min(hidden.length - 1, lower.length); k > 0; k--) {
+    if (lower.endsWith(hidden.slice(0, k))) {
+      cut = text.length - k;
+      break;
+    }
+  }
+  return scrubOpenCardAnswer(text.slice(0, cut), card);
 }
 
 // The word on the table: the most recent [SERVED] card with no later

--- a/app/v2/components/ChatWindow.tsx
+++ b/app/v2/components/ChatWindow.tsx
@@ -232,6 +232,9 @@ export function ChatWindow() {
   // Background tutor commentary in flight (post-verdict) -- shows the typing
   // indicator without blocking the chips, so Next word stays available.
   const [commentaryPending, setCommentaryPending] = useState(false);
+  // Local id of the assistant bubble currently receiving streamed text --
+  // the typing indicator yields to it once words are visibly arriving.
+  const [streamingId, setStreamingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   // The next card, fetched while the user reads the current verdict, so
   // Next word renders with zero wait.
@@ -566,9 +569,112 @@ export function ChatWindow() {
     return message?.widgets?.[index] ?? null;
   }
 
+  // Streams the tutor's reply into a local placeholder bubble as the model
+  // generates it, then swaps in the persisted message (real id + widgets)
+  // when the turn completes. Returns that final message.
+  async function streamChat(text: string): Promise<V2Message> {
+    const res = await apiFetch("/api/v2/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
+      body: JSON.stringify({ conversationId, message: text }),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => null);
+      const raw = data && (data as { error?: unknown }).error;
+      throw new Error(typeof raw === "string" ? raw : "That message didn't send.");
+    }
+    // A non-SSE response (older deploy, proxy stripped the header) still
+    // carries the standard JSON body -- fall through to it.
+    if (!res.headers.get("content-type")?.includes("text/event-stream") || !res.body) {
+      const data = (await res.json()) as { conversationId: string; message: V2Message };
+      setConversationId(data.conversationId);
+      return data.message;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let placeholderId: string | null = null;
+
+    const updatePlaceholder = (content: string) => {
+      if (!content) return;
+      if (!placeholderId) {
+        placeholderId = nextLocalId();
+        setStreamingId(placeholderId);
+        const id = placeholderId;
+        setMessages((prev) => [
+          ...prev,
+          {
+            id,
+            conversation_id: conversationId ?? "",
+            role: "assistant",
+            content,
+            widgets: [],
+            created_at: new Date().toISOString(),
+          },
+        ]);
+      } else {
+        const id = placeholderId;
+        setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, content } : m)));
+      }
+      // Growing text doesn't change message COUNT, so the length-keyed
+      // auto-scroll effect never fires -- keep the tail in view directly.
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    };
+
+    try {
+      let finalMessage: V2Message | null = null;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const event = JSON.parse(line.slice(6)) as {
+            type: string;
+            partial?: string;
+            conversationId?: string;
+            message?: V2Message;
+            error?: string;
+          };
+          if (event.type === "text" && typeof event.partial === "string") {
+            updatePlaceholder(event.partial);
+          } else if (event.type === "done" && event.message) {
+            finalMessage = event.message;
+            if (event.conversationId) setConversationId(event.conversationId);
+          } else if (event.type === "error") {
+            throw new Error(event.error || "That message didn't send.");
+          }
+        }
+      }
+      if (!finalMessage) throw new Error("The tutor's reply was cut off — try again.");
+      const message = finalMessage;
+      setMessages((prev) =>
+        placeholderId
+          ? prev.map((m) => (m.id === placeholderId ? message : m))
+          : [...prev, message]
+      );
+      return message;
+    } catch (err) {
+      // Take the half-streamed bubble back out -- the caller's error path
+      // also removes the optimistic user message.
+      if (placeholderId) {
+        const id = placeholderId;
+        setMessages((prev) => prev.filter((m) => m.id !== id));
+      }
+      throw err;
+    } finally {
+      setStreamingId(null);
+    }
+  }
+
   // background: true keeps the chips alive while the tutor works -- used for
   // hidden ground-truth messages ([REVIEW RESULT] etc.) whose commentary is
-  // a nicety, not something the user should wait on.
+  // a nicety, not something the user should wait on. Background sends stay on
+  // the JSON path: their reply may need to splice ABOVE an already-served
+  // card (race guard below), which is incompatible with streaming in place.
   async function sendMessage(text: string, { background = false } = {}): Promise<boolean> {
     if (!text.trim()) return false;
     if (background) setCommentaryPending(true);
@@ -588,6 +694,10 @@ export function ChatWindow() {
     ]);
 
     try {
+      if (!background) {
+        await streamChat(text);
+        return true;
+      }
       const data = await fetchJSON<{ conversationId: string; message: V2Message }>("/api/v2/chat", {
         conversationId,
         message: text,
@@ -598,18 +708,16 @@ export function ChatWindow() {
         // to a new card, this reply is about the PREVIOUS word -- slot it in
         // before the new card so it stays with its own exchange instead of
         // reading as a reply to the card on the table.
-        if (background) {
-          for (let i = prev.length - 1; i >= 0; i--) {
-            const widgets = prev[i].widgets ?? [];
-            const j = widgets.findIndex((w) => isReviewWidget(w));
-            if (j === -1) continue;
-            if (!answeredKeysRef.current.has(`${prev[i].id}:${j}`)) {
-              const copy = [...prev];
-              copy.splice(i, 0, data.message);
-              return copy;
-            }
-            break;
+        for (let i = prev.length - 1; i >= 0; i--) {
+          const widgets = prev[i].widgets ?? [];
+          const j = widgets.findIndex((w) => isReviewWidget(w));
+          if (j === -1) continue;
+          if (!answeredKeysRef.current.has(`${prev[i].id}:${j}`)) {
+            const copy = [...prev];
+            copy.splice(i, 0, data.message);
+            return copy;
           }
+          break;
         }
         return [...prev, data.message];
       });
@@ -1470,7 +1578,7 @@ export function ChatWindow() {
                 ))
               )}
             </AnimatePresence>
-            {(loading || checking || commentaryPending) && (
+            {(loading || checking || commentaryPending) && !streamingId && (
               <TypingIndicator label={checking ? "Checking your answer..." : undefined} />
             )}
           </div>


### PR DESCRIPTION
## Summary

The V2 tutor's replies now stream into the chat bubble as the model generates them, instead of arriving all at once after the full tool loop completes. This is where streaming is most noticeable — tutor replies (explanations, examples, hints) are much longer than the V1 hint/sentence responses that got streaming in #30.

## How it works

**Server** (`app/api/v2/chat/route.ts`)
- The chat endpoint gains an SSE mode, opt-in via `Accept: text/event-stream`. The existing JSON path is unchanged (used by bootstrap and background commentary).
- The tool loop is shared between both response modes. In streaming mode, each model call's text rides out as **full-replace snapshots** — a later tool-loop iteration's text cleanly replaces an earlier one's, and the client needs no delta bookkeeping.
- The final SSE event carries the persisted message (real id + widgets).
- **The hint-leak guard applies during streaming, not just to the stored row**: every snapshot is scrubbed of the open card's hidden answer, and a trailing *partial* match is held back until it either completes (and gets scrubbed) or diverges — the answer can never flash on screen mid-generation. Verified token-by-token in simulation.

**Client** (`app/v2/components/ChatWindow.tsx`)
- Foreground sends stream into a local placeholder bubble, swapped for the persisted message on completion.
- The typing indicator yields once text is visibly arriving; the transcript keeps the growing tail in view.
- Background `[REVIEW RESULT]` commentary stays on the JSON path — its reply may need to splice above an already-served card (the existing race guard), which is incompatible with streaming in place.
- Non-SSE responses (older deploy, proxy stripped the header) fall back to the JSON body.

## Test plan

- [ ] Ask the tutor a question — reply text should stream into the bubble word by word
- [ ] Tap "Explain more" / "Give an example" on a verdict — streams
- [ ] Take a hint on an open card — the hint streams and never reveals the answer (hidden side scrubbed live)
- [ ] Answer a card — verdict + background commentary still work (JSON path, splice guard intact)
- [ ] Add words / start a pack — widgets still arrive with the final message
- [ ] `npm run lint` clean, all 517 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYZiPWwYb2kDqVU9dRbrzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYZiPWwYb2kDqVU9dRbrzJ)_