### PR TITLE
Fix tutor chat 400: disable thinking on Sonnet 5 tool loop

### DIFF
--- a/app/api/v2/chat/route.ts
+++ b/app/api/v2/chat/route.ts
@@ -157,8 +157,18 @@ export async function POST(req: Request) {
       let lastStopReason: string | null = null;
 
       for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
-        const stream = anthropic.messages.stream({
+        // Sonnet 5 runs adaptive thinking when `thinking` is omitted, and by
+        // default its thinking blocks carry empty text. SDK 0.32.x predates
+        // thinking, so the stream accumulator reassembles those blocks badly,
+        // and echoing them back through the tool loop 400s with "each
+        // thinking block must contain thinking". The tutor doesn't need
+        // thinking (the deterministic layer owns correctness), so disable it.
+        // Passed via a variable so the extra `thinking` field (unknown to the
+        // 0.32.x types) skips excess-property checking, same reason as the
+        // cache_control cast above.
+        const request = {
           model: MODEL,
+          thinking: { type: "disabled" as const },
           // Must fit a propose_words call for a long pasted list -- at 1024 the
           // tool_use block gets truncated and silently dropped, so the reply
           // text lands without its widget.
@@ -166,7 +176,8 @@ export async function POST(req: Request) {
           system,
           tools,
           messages,
-        });
+        };
+        const stream = anthropic.messages.stream(request);
 
         if (onText) {
           let accumulated = "";


### PR DESCRIPTION
## Problem

The V2 tutor chat intermittently fails mid-conversation with:

```
Chat failed: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.23.content...: each thinking block must contain thinking"}}
```

## Cause

`app/api/v2/chat/route.ts` calls `claude-sonnet-5` without a `thinking` parameter. On Sonnet 5, omitting `thinking` runs **adaptive thinking by default**, and by default those thinking blocks carry empty text. The tool loop echoes `response.content` back verbatim on the next iteration, so the API rejects the resent empty thinking block and the whole turn 500s.

The pinned SDK (`@anthropic-ai/sdk` 0.32.x) also predates thinking support entirely, so its stream accumulator can't reassemble thinking blocks correctly even if we wanted them.

## Fix

Explicitly pass `thinking: { type: "disabled" }` on the chat request. The tutor doesn't need thinking — the deterministic layer owns grading/scheduling correctness and Sonnet was chosen for latency — and this also stops thinking from eating into the 4096-token output budget.

The request object is passed via a variable so the `thinking` field (unknown to the 0.32.x SDK types) bypasses TypeScript's excess-property check, following the same pattern as the existing `cache_control` cast.

## Verification

- `npx tsc --noEmit` — no errors in touched files (pre-existing test-file errors unchanged)
- `npm run lint` — clean
- Smoke test with a mocked fetch confirms SDK 0.32.x forwards `"thinking":{"type":"disabled"}` in the outgoing request body and `finalMessage()` still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rj7U2aMRy2yWp3ePbPNjc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rj7U2aMRy2yWp3ePbPNjc5)_