### PR TITLE
Make tutor streaming visible, match backdrop to verdict, align typing indicator

### DIFF
--- a/app/api/v2/chat/route.ts
+++ b/app/api/v2/chat/route.ts
@@ -74,25 +74,37 @@ export async function POST(req: Request) {
       return NextResponse.json({ conversationId, message: assistantMessage });
     }
 
-    await insertMessage(supabase, conversationId, "user", body.message, []);
+    // These four round trips are independent, and the function may sit an
+    // ocean away from the database -- run them concurrently, it's seconds of
+    // time-to-first-token. The history select races the user-message insert,
+    // so the new turn may or may not be in the result; it's reconciled below.
+    const [, historyResult, languageId, settingsResult] = await Promise.all([
+      insertMessage(supabase, conversationId, "user", body.message, []),
+      supabase
+        .from("v2_messages")
+        .select("role, content")
+        .eq("conversation_id", conversationId)
+        .order("created_at", { ascending: true }),
+      getDefaultLanguageId(supabase),
+      // The user-editable slice of the tutor's behavior rides at the end of
+      // the system prompt; the tutor can rewrite it via update_instructions.
+      supabase
+        .from("v2_user_settings")
+        .select("tutor_instructions")
+        .eq("user_id", user.id)
+        .maybeSingle(),
+    ]);
+    if (historyResult.error) throw historyResult.error;
+    let historyRows = historyResult.data;
+    // If the select won the race, this turn's user message is missing --
+    // append it. (When the insert won, it's necessarily the last row.)
+    const lastRow = historyRows?.[historyRows.length - 1];
+    if (!lastRow || lastRow.role !== "user" || lastRow.content !== body.message) {
+      historyRows = [...(historyRows ?? []), { role: "user", content: body.message }];
+    }
 
-    const { data: historyRows, error: historyError } = await supabase
-      .from("v2_messages")
-      .select("role, content")
-      .eq("conversation_id", conversationId)
-      .order("created_at", { ascending: true });
-    if (historyError) throw historyError;
-
-    const languageId = await getDefaultLanguageId(supabase);
     const ctx = { supabase, userId: user.id, languageId };
-
-    // The user-editable slice of the tutor's behavior rides at the end of
-    // the system prompt; the tutor can rewrite it via update_instructions.
-    const { data: settings } = await supabase
-      .from("v2_user_settings")
-      .select("tutor_instructions")
-      .eq("user_id", user.id)
-      .maybeSingle();
+    const settings = settingsResult.data;
     const instructions = settings?.tutor_instructions?.trim() || DEFAULT_TUTOR_INSTRUCTIONS;
     // Prompt caching: tools + the static prompt + the per-user instructions
     // are stable across turns, so cache breakpoints cut latency (and cost)

--- a/app/v2/components/ChatWindow.tsx
+++ b/app/v2/components/ChatWindow.tsx
@@ -363,6 +363,17 @@ export function ChatWindow() {
     return null;
   }, [visibleMessages]);
   const verdictShowing = !pending && verdictIndex !== null;
+  const verdictWidget = useMemo(() => {
+    if (verdictIndex === null) return null;
+    return (
+      (visibleMessages[verdictIndex].widgets ?? []).find(
+        (w): w is Extract<Widget, { type: "review_verdict" }> => w.type === "review_verdict"
+      ) ?? null
+    );
+  }, [visibleMessages, verdictIndex]);
+  // A miss (or reveal) puts a red card on stage -- the shell's green wash
+  // follows it so the backdrop matches the card instead of clashing.
+  const missShowing = verdictShowing && verdictWidget !== null && !verdictWidget.correct;
 
   // The steady view shows only the active exchange: the last assistant
   // message (plus the user message that prompted it), extended back to keep
@@ -602,7 +613,7 @@ export function ChatWindow() {
     let buffer = "";
     let placeholderId: string | null = null;
 
-    const updatePlaceholder = (content: string) => {
+    const renderPlaceholder = (content: string) => {
       if (!content) return;
       if (!placeholderId) {
         placeholderId = nextLocalId();
@@ -626,6 +637,27 @@ export function ChatWindow() {
       // Growing text doesn't change message COUNT, so the length-keyed
       // auto-scroll effect never fires -- keep the tail in view directly.
       scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    };
+
+    // Short replies generate fast and arrive in a couple of big snapshots,
+    // which on screen reads as "no streaming at all". Reveal the text at a
+    // reading pace instead, accelerating with the backlog so a long reply
+    // never lags the wire by more than a beat.
+    let revealTarget = "";
+    let revealShown = 0;
+    let revealFrame: number | null = null;
+    const revealTick = () => {
+      revealFrame = null;
+      revealShown = Math.min(revealShown, revealTarget.length);
+      const backlog = revealTarget.length - revealShown;
+      if (backlog === 0) return;
+      revealShown += Math.min(Math.max(2, Math.ceil(backlog / 6)), 24);
+      renderPlaceholder(revealTarget.slice(0, Math.min(revealShown, revealTarget.length)));
+      if (revealShown < revealTarget.length) revealFrame = requestAnimationFrame(revealTick);
+    };
+    const updatePlaceholder = (content: string) => {
+      revealTarget = content;
+      if (revealFrame === null) revealFrame = requestAnimationFrame(revealTick);
     };
 
     try {
@@ -672,6 +704,9 @@ export function ChatWindow() {
       }
       throw err;
     } finally {
+      // A queued reveal frame firing after the swap would re-create the
+      // placeholder bubble next to the real message.
+      if (revealFrame !== null) cancelAnimationFrame(revealFrame);
       setStreamingId(null);
     }
   }
@@ -1286,10 +1321,7 @@ export function ChatWindow() {
     if (verdictShowing) {
       // One-tap dispute on a miss: the tutor sees the submitted answer in
       // [REVIEW RESULT] and regrades when the case is fair.
-      const verdict = (visibleMessages[verdictIndex!].widgets ?? []).find(
-        (w): w is Extract<Widget, { type: "review_verdict" }> => w.type === "review_verdict"
-      );
-      const disputable = verdict && !verdict.correct && !verdict.conceded;
+      const disputable = verdictWidget && !verdictWidget.correct && !verdictWidget.conceded;
       return [
         {
           label: "Next word",
@@ -1426,9 +1458,25 @@ export function ChatWindow() {
     // prefers-reduced-motion users -- per-component checks don't scale.
     <MotionConfig reducedMotion="user">
     <div
-      className="flex h-[100dvh] bg-gradient-to-b from-green-50/80 via-white to-white"
+      className="relative isolate flex h-[100dvh] bg-white"
       style={{ paddingTop: "env(safe-area-inset-top)", paddingBottom: "env(safe-area-inset-bottom)" }}
     >
+      {/* Gradients can't transition, so the green and red washes are two
+          layers cross-fading behind the content. */}
+      <div
+        aria-hidden
+        className={cn(
+          "absolute inset-0 -z-10 bg-gradient-to-b from-green-50/80 via-white to-white transition-opacity duration-700",
+          missShowing && "opacity-0"
+        )}
+      />
+      <div
+        aria-hidden
+        className={cn(
+          "absolute inset-0 -z-10 bg-gradient-to-b from-red-50/60 via-white to-white transition-opacity duration-700",
+          !missShowing && "opacity-0"
+        )}
+      />
       <div className="relative flex flex-col flex-1 min-w-0">
         {/* V2 owns its shell: the logo is the app menu (log out, old app). */}
         <div className="hidden lg:block absolute top-4 left-4 z-10">

--- a/app/v2/components/ChatWindow.tsx
+++ b/app/v2/components/ChatWindow.tsx
@@ -688,6 +688,20 @@ export function ChatWindow() {
         }
       }
       if (!finalMessage) throw new Error("The tutor's reply was cut off — try again.");
+      // Let the reveal finish typing before the persisted message (full text
+      // + widgets) replaces the placeholder -- a short reply's tail arrives
+      // in the same beat as "done", and swapping right away would snap it to
+      // complete before any typing is seen. Capped so a throttled background
+      // tab can't stall the turn.
+      if (revealShown < revealTarget.length) {
+        await Promise.race([
+          new Promise<void>((resolve) => {
+            const poll = () => (revealShown >= revealTarget.length ? resolve() : window.setTimeout(poll, 40));
+            poll();
+          }),
+          new Promise<void>((resolve) => window.setTimeout(resolve, 2000)),
+        ]);
+      }
       const message = finalMessage;
       setMessages((prev) =>
         placeholderId

--- a/app/v2/components/TypingIndicator.tsx
+++ b/app/v2/components/TypingIndicator.tsx
@@ -5,7 +5,10 @@
 // your answer") from ordinary tutor thinking.
 export function TypingIndicator({ label }: { label?: string }) {
   return (
-    <div className="w-full max-w-md mx-auto flex items-center gap-2.5" aria-live="polite">
+    // Left-anchored like TutorStrip so the avatar sits exactly where the
+    // tutor's next bubble will land -- centered, it floated between the
+    // bubble column and the cards and lined up with neither.
+    <div className="w-full max-w-lg flex items-center gap-2.5" aria-live="polite">
       <img src="/logo.svg" alt="" className="w-6 h-6 shrink-0" />
       <div className="flex items-center gap-2 rounded-2xl bg-white border border-gray-200 shadow-sm px-3.5 py-2.5">
         <span className="flex items-center gap-1">


### PR DESCRIPTION
## Why streaming looked broken

Streaming already works at the transport level — probing the production `/api/v2/chat` endpoint shows SSE chunks arriving incrementally. What makes it *look* broken is the shape: **~5.5s of dead air to the first token, then a short two-sentence reply lands within ~0.8s** in a couple of big snapshots. Perceptually that's "typing indicator forever, then the whole reply pops in."

## Changes

### Cut time-to-first-token (`app/api/v2/chat/route.ts`)
The user-message insert, history select, settings select, and language lookup were four sequential round trips — from a Vercel function that can sit an ocean away from the Supabase database (function ran in `iad1` during the probe; the DB is in `eu-west-2`). They're independent, so they now run in one `Promise.all`. The insert/select race is reconciled deterministically: if the select won, the missing user turn is appended.

### Make the reveal visible (`app/v2/components/ChatWindow.tsx`)
Streamed snapshots are now revealed at a reading pace via `requestAnimationFrame` (accelerating with the backlog, so long replies never trail the wire by more than a beat) instead of replacing the bubble with whole sentences at once. The pending frame is cancelled when the stream ends so it can't resurrect the placeholder after the final message swaps in.

### Backdrop follows the verdict card (`ChatWindow.tsx`)
The shell's green wash clashed with the red card on a miss/reveal. The gradient is now two cross-fading layers: green normally, a soft matching red wash while a red verdict is on stage.

### Typing indicator alignment (`app/v2/components/TypingIndicator.tsx`)
It was centered (`max-w-md mx-auto`) while tutor bubbles are left-anchored, so its avatar floated between the bubble column and the cards, lining up with neither. Now left-anchored like `TutorStrip`.

## Verification
- Probed production SSE with an authenticated request: chunks stream incrementally (transport confirmed fine).
- Drove the review flow in a local browser against the real backend: red verdict now sits on a red wash (screenshot-verified), typing indicator aligns with the tutor bubble column.
- `npm run lint` clean; all 523 vitest tests pass; `tsc` error count unchanged vs `main`.

## Worth considering (dashboard, not code)
The Vercel project's function region appears to be `iad1` while Supabase is in `eu-west-2` (London). Setting the function region to `lhr1` in the Vercel dashboard would shave several hundred ms of per-turn latency across every API route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QKNDVmRMNavZ1Ug3A1ofV

---
_Generated by [Claude Code](https://claude.ai/code/session_015QKNDVmRMNavZ1Ug3A1ofV)_